### PR TITLE
Split vTableReplicated into two RDDs

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -4,6 +4,7 @@ import scala.collection.JavaConversions._
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ArrayBuilder
 
 import org.apache.spark.SparkContext._
 import org.apache.spark.Partitioner
@@ -501,11 +502,11 @@ object GraphImpl {
 
     val vTableReplicatedValues: IndexedRDD[Pid, Array[VD]] =
       msgsByPartition.mapPartitionsWithIndex( (pid, iter) => {
-        val vertexArray = new ArrayBuffer[VD]
+        val vertexArray = ArrayBuilder.make[VD]
         for (msg <- iter) {
           vertexArray += msg.data._2
         }
-        Array((pid, vertexArray.toArray)).iterator
+        Array((pid, vertexArray.result)).iterator
       }, preservesPartitioning = true).indexed(eTable.index)
 
     (vTableReplicationMap, vTableReplicatedValues)

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -486,7 +486,8 @@ object GraphImpl {
         .flatMap { case (vid, (vdata, pids)) =>
           pids.iterator.map { pid => MessageToPartition(pid, (vid, vdata)) }
         }
-        .partitionBy(eTable.partitioner.get) //@todo assert edge table has partitioner
+        .partitionBy(eTable.partitioner.get).cache()
+    // @todo assert edge table has partitioner
 
     val vTableReplicationMap: IndexedRDD[Pid, VertexIdToIndexMap] =
       msgsByPartition.mapPartitionsWithIndex( (pid, iter) => {

--- a/graph/src/main/scala/org/apache/spark/graph/package.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/package.scala
@@ -8,6 +8,8 @@ package object graph {
   type VertexHashMap[T] = it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap[T]
   type VertexSet = it.unimi.dsi.fastutil.longs.LongOpenHashSet
   type VertexArrayList = it.unimi.dsi.fastutil.longs.LongArrayList
+  // @todo replace with rxin's fast hashmap
+  type VertexIdToIndexMap = scala.collection.mutable.HashMap[Vid, Int]
 
   /**
    * Return the default null-like value for a data type T.


### PR DESCRIPTION
Previously, `(vTableReplicated: IndexedRDD[Pid, VertexHashMap[VD]])` stored one hashmap per partition, taking vertex IDs directly to vertex attributes.

To take advantage of @rxin's new hashmaps (see rxin/incubator-spark@32a79d6d13be8a03071296d251a3e532bf964cc0), this pull request splits that data structure into two RDDs:

`(vTableReplicationMap: IndexedRDD[Pid, VertexIdToIndexMap])` stores a map per partition from vertex ID to the array index where that vertex's attribute is stored. This index refers to an array in the same partition in `vTableReplicatedValues`.

`(vTableReplicatedValues: IndexedRDD[Pid, Array[VD]])` stores the vertex data and is arranged as described above.

As a sanity check, this change passes GraphSuite, but I haven't performed any further testing.
