### PR TITLE
Refactoring IndexedRDD to VertexSetRDD.

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/Graph.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Graph.scala
@@ -28,7 +28,7 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
    * @see Vertex for the vertex type.
    *
    */
-  val vertices: RDD[(Vid,VD)]
+  val vertices: VertexSetRDD[VD]
 
   /**
    * Get the Edges and their data as an RDD.  The entries in the RDD contain
@@ -257,7 +257,7 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
   def mapReduceTriplets[A: ClassManifest](
       mapFunc: EdgeTriplet[VD, ED] => Array[(Vid, A)],
       reduceFunc: (A, A) => A)
-    : RDD[(Vid, A)] 
+    : VertexSetRDD[A] 
 
 
   /**


### PR DESCRIPTION
1) This allows the index map to be optimized for Vids
2) This makes the code more readable
2) The Graph API can now return VertexSetRDDs from operations that produce results for vertices
