### PR TITLE
Shuffle replicated vertex attributes efficiently in columnar format

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
@@ -18,6 +18,7 @@ class GraphKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[EdgePartition[Object]])
     kryo.register(classOf[BitSet])
     kryo.register(classOf[VertexIdToIndexMap])
+    kryo.register(classOf[VertexAttributeBlock[Object]])
     // This avoids a large number of hash table lookups.
     kryo.setReferences(false)
   }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -170,7 +170,7 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
     println("\n\nvid2pid.bothAttrs -------------------------------")
     traverseLineage(vid2pid.bothAttrs, "  ", visited)
     visited += (vid2pid.bothAttrs.id -> "vid2pid")
-    visited += (vid2pid.bothAttrs.valuesRDD.id -> "vid2pid.values")
+    visited += (vid2pid.bothAttrs.valuesRDD.id -> "vid2pid.bothAttrs")
 
     println("\n\nlocalVidMap -------------------------------------")
     traverseLineage(localVidMap, "  ", visited)

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicatedValues.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicatedValues.scala
@@ -1,0 +1,72 @@
+package org.apache.spark.graph.impl
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.util.collection.OpenHashSet
+
+import org.apache.spark.graph._
+import org.apache.spark.graph.impl.MsgRDDFunctions._
+
+/**
+ * Stores the vertex attribute values after they are replicated. See
+ * the description of localVidMap in [[GraphImpl]].
+ */
+class VTableReplicatedValues[VD: ClassManifest](
+    vTable: VertexSetRDD[VD],
+    vid2pid: Vid2Pid,
+    localVidMap: RDD[(Pid, VertexIdToIndexMap)]) {
+
+  val bothAttrs: RDD[(Pid, Array[VD])] =
+    VTableReplicatedValues.createVTableReplicated(vTable, vid2pid, localVidMap, true, true)
+  val srcAttrOnly: RDD[(Pid, Array[VD])] =
+    VTableReplicatedValues.createVTableReplicated(vTable, vid2pid, localVidMap, true, false)
+  val dstAttrOnly: RDD[(Pid, Array[VD])] =
+    VTableReplicatedValues.createVTableReplicated(vTable, vid2pid, localVidMap, false, true)
+  val noAttrs: RDD[(Pid, Array[VD])] =
+    VTableReplicatedValues.createVTableReplicated(vTable, vid2pid, localVidMap, false, false)
+
+
+  def get(includeSrcAttr: Boolean, includeDstAttr: Boolean): RDD[(Pid, Array[VD])] =
+    (includeSrcAttr, includeDstAttr) match {
+      case (true, true) => bothAttrs
+      case (true, false) => srcAttrOnly
+      case (false, true) => dstAttrOnly
+      case (false, false) => noAttrs
+    }
+}
+
+
+
+object VTableReplicatedValues {
+  protected def createVTableReplicated[VD: ClassManifest](
+      vTable: VertexSetRDD[VD],
+      vid2pid: Vid2Pid,
+      localVidMap: RDD[(Pid, VertexIdToIndexMap)],
+      includeSrcAttr: Boolean,
+      includeDstAttr: Boolean): RDD[(Pid, Array[VD])] = {
+
+    // Join vid2pid and vTable, generate a shuffle dependency on the joined
+    // result, and get the shuffle id so we can use it on the slave.
+    val msgsByPartition = vTable.zipJoinFlatMap(vid2pid.get(includeSrcAttr, includeDstAttr)) {
+      // TODO(rxin): reuse VertexBroadcastMessage
+      (vid, vdata, pids) => pids.iterator.map { pid =>
+        new VertexBroadcastMsg[VD](pid, vid, vdata)
+      }
+    }.partitionBy(localVidMap.partitioner.get).cache()
+
+    localVidMap.zipPartitions(msgsByPartition){
+      (mapIter, msgsIter) =>
+      val (pid, vidToIndex) = mapIter.next()
+      assert(!mapIter.hasNext)
+      // Populate the vertex array using the vidToIndex map
+      val vertexArray = new Array[VD](vidToIndex.capacity)
+      for (msg <- msgsIter) {
+        val ind = vidToIndex.getPos(msg.vid) & OpenHashSet.POSITION_MASK
+        vertexArray(ind) = msg.data
+      }
+      Iterator((pid, vertexArray))
+    }.cache()
+
+    // @todo assert edge table has partitioner
+  }
+
+}

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicatedValues.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicatedValues.scala
@@ -1,7 +1,10 @@
 package org.apache.spark.graph.impl
 
+import scala.collection.mutable.ArrayBuilder
+
+import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.util.collection.OpenHashSet
+import org.apache.spark.util.collection.{OpenHashSet, PrimitiveKeyOpenHashMap}
 
 import org.apache.spark.graph._
 import org.apache.spark.graph.impl.MsgRDDFunctions._
@@ -34,7 +37,7 @@ class VTableReplicatedValues[VD: ClassManifest](
     }
 }
 
-
+class VertexAttributeBlock[VD: ClassManifest](val vids: Array[Vid], val attrs: Array[VD])
 
 object VTableReplicatedValues {
   protected def createVTableReplicated[VD: ClassManifest](
@@ -44,13 +47,30 @@ object VTableReplicatedValues {
       includeSrcAttr: Boolean,
       includeDstAttr: Boolean): RDD[(Pid, Array[VD])] = {
 
-    // Join vid2pid and vTable, generate a shuffle dependency on the joined
-    // result, and get the shuffle id so we can use it on the slave.
-    val msgsByPartition = vTable.zipJoinFlatMap(vid2pid.get(includeSrcAttr, includeDstAttr)) {
-      // TODO(rxin): reuse VertexBroadcastMessage
-      (vid, vdata, pids) => pids.iterator.map { pid =>
-        new VertexBroadcastMsg[VD](pid, vid, vdata)
+    // Within each partition of vid2pid, construct a pid2vid mapping
+    val numPartitions = vTable.partitions.size
+    val pid2vid = vid2pid.get(includeSrcAttr, includeDstAttr).mapPartitions { iter =>
+      val pid2vidLocal = Array.fill[ArrayBuilder[Vid]](numPartitions)(ArrayBuilder.make[Vid])
+      for ((vid, pids) <- iter) {
+        pids.foreach { pid => pid2vidLocal(pid) += vid }
       }
+      Iterator(pid2vidLocal.map(_.result))
+    }
+
+    val msgsByPartition = pid2vid.zipPartitions(vTable.index.rdd, vTable.valuesRDD) {
+      (pid2vidIter, indexIter, valuesIter) =>
+      val pid2vid = pid2vidIter.next()
+      val index = indexIter.next()
+      val values = valuesIter.next()
+      val vmap = new PrimitiveKeyOpenHashMap(index, values._1)
+
+      // Send each partition the vertex attributes it wants
+      val output = new Array[(Pid, VertexAttributeBlock[VD])](pid2vid.size)
+      for (pid <- 0 until pid2vid.size) {
+        val block = new VertexAttributeBlock(pid2vid(pid), pid2vid(pid).map(vid => vmap(vid)))
+        output(pid) = (pid, block)
+      }
+      output.iterator
     }.partitionBy(localVidMap.partitioner.get).cache()
 
     localVidMap.zipPartitions(msgsByPartition){
@@ -59,14 +79,16 @@ object VTableReplicatedValues {
       assert(!mapIter.hasNext)
       // Populate the vertex array using the vidToIndex map
       val vertexArray = new Array[VD](vidToIndex.capacity)
-      for (msg <- msgsIter) {
-        val ind = vidToIndex.getPos(msg.vid) & OpenHashSet.POSITION_MASK
-        vertexArray(ind) = msg.data
+      for ((_, block) <- msgsIter) {
+        for (i <- 0 until block.vids.size) {
+          val vid = block.vids(i)
+          val attr = block.attrs(i)
+          val ind = vidToIndex.getPos(vid) & OpenHashSet.POSITION_MASK
+          vertexArray(ind) = attr
+        }
       }
       Iterator((pid, vertexArray))
     }.cache()
-
-    // @todo assert edge table has partitioner
   }
 
 }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/Vid2Pid.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/Vid2Pid.scala
@@ -1,0 +1,48 @@
+package org.apache.spark.graph.impl
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.graph._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+
+/**
+ * Stores the layout of vertex attributes.
+ */
+class Vid2Pid(
+    eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
+    vTableIndex: VertexSetIndex) {
+
+  val bothAttrs: VertexSetRDD[Array[Pid]] = createVid2Pid(true, true)
+  val srcAttrOnly: VertexSetRDD[Array[Pid]] = createVid2Pid(true, false)
+  val dstAttrOnly: VertexSetRDD[Array[Pid]] = createVid2Pid(false, true)
+  // TODO(ankurdave): create this more efficiently
+  val noAttrs: VertexSetRDD[Array[Pid]] = createVid2Pid(false, false)
+
+  def persist(newLevel: StorageLevel) {
+    bothAttrs.persist(newLevel)
+    srcAttrOnly.persist(newLevel)
+    dstAttrOnly.persist(newLevel)
+    noAttrs.persist(newLevel)
+  }
+
+  private def createVid2Pid(
+    includeSrcAttr: Boolean,
+    includeDstAttr: Boolean): VertexSetRDD[Array[Pid]] = {
+    val preAgg = eTable.mapPartitions { iter =>
+      val (pid, edgePartition) = iter.next()
+      val vSet = new VertexSet
+      edgePartition.foreach(e => {
+        if (includeSrcAttr) vSet.add(e.srcId)
+        if (includeDstAttr) vSet.add(e.dstId)
+      })
+      vSet.iterator.map { vid => (vid.toLong, pid) }
+    }
+    VertexSetRDD[Pid, ArrayBuffer[Pid]](preAgg, vTableIndex,
+      (p: Pid) => ArrayBuffer(p),
+      (ab: ArrayBuffer[Pid], p:Pid) => {ab.append(p); ab},
+      (a: ArrayBuffer[Pid], b: ArrayBuffer[Pid]) => a ++ b)
+      .mapValues(a => a.toArray).cache()
+  }
+}

--- a/graph/src/main/scala/org/apache/spark/graph/impl/Vid2Pid.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/Vid2Pid.scala
@@ -2,6 +2,7 @@ package org.apache.spark.graph.impl
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ArrayBuilder
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -20,12 +21,25 @@ class Vid2Pid(
   val dstAttrOnly: VertexSetRDD[Array[Pid]] = createVid2Pid(false, true)
   val noAttrs: VertexSetRDD[Array[Pid]] = createVid2Pid(false, false)
 
+  val pid2VidBothAttrs: RDD[Array[Array[Vid]]] = createPid2Vid(bothAttrs)
+  val pid2VidSrcAttrOnly: RDD[Array[Array[Vid]]] = createPid2Vid(srcAttrOnly)
+  val pid2VidDstAttrOnly: RDD[Array[Array[Vid]]] = createPid2Vid(dstAttrOnly)
+  val pid2VidNoAttrs: RDD[Array[Array[Vid]]] = createPid2Vid(noAttrs)
+
   def get(includeSrcAttr: Boolean, includeDstAttr: Boolean): VertexSetRDD[Array[Pid]] =
     (includeSrcAttr, includeDstAttr) match {
       case (true, true) => bothAttrs
       case (true, false) => srcAttrOnly
       case (false, true) => dstAttrOnly
       case (false, false) => noAttrs
+    }
+
+  def getPid2Vid(includeSrcAttr: Boolean, includeDstAttr: Boolean): RDD[Array[Array[Vid]]] =
+    (includeSrcAttr, includeDstAttr) match {
+      case (true, true) => pid2VidBothAttrs
+      case (true, false) => pid2VidSrcAttrOnly
+      case (false, true) => pid2VidDstAttrOnly
+      case (false, false) => pid2VidNoAttrs
     }
 
   def persist(newLevel: StorageLevel) {
@@ -54,5 +68,20 @@ class Vid2Pid(
       (ab: ArrayBuffer[Pid], p:Pid) => {ab.append(p); ab},
       (a: ArrayBuffer[Pid], b: ArrayBuffer[Pid]) => a ++ b)
       .mapValues(a => a.toArray).cache()
+  }
+
+  /**
+   * Creates an intermediate pid2vid structure that tells each partition of the
+   * vertex data where it should go.
+   */
+  private def createPid2Vid(vid2pid: VertexSetRDD[Array[Pid]]): RDD[Array[Array[Vid]]] = {
+    val numPartitions = vid2pid.partitions.size
+    vid2pid.mapPartitions { iter =>
+      val pid2vidLocal = Array.fill[ArrayBuilder[Vid]](numPartitions)(ArrayBuilder.make[Vid])
+      for ((vid, pids) <- iter) {
+        pids.foreach { pid => pid2vidLocal(pid) += vid }
+      }
+      Iterator(pid2vidLocal.map(_.result))
+    }
   }
 }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/Vid2Pid.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/Vid2Pid.scala
@@ -3,12 +3,13 @@ package org.apache.spark.graph.impl
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.graph._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 
+import org.apache.spark.graph._
+
 /**
- * Stores the layout of vertex attributes.
+ * Stores the layout of vertex attributes for GraphImpl.
  */
 class Vid2Pid(
     eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
@@ -17,8 +18,15 @@ class Vid2Pid(
   val bothAttrs: VertexSetRDD[Array[Pid]] = createVid2Pid(true, true)
   val srcAttrOnly: VertexSetRDD[Array[Pid]] = createVid2Pid(true, false)
   val dstAttrOnly: VertexSetRDD[Array[Pid]] = createVid2Pid(false, true)
-  // TODO(ankurdave): create this more efficiently
   val noAttrs: VertexSetRDD[Array[Pid]] = createVid2Pid(false, false)
+
+  def get(includeSrcAttr: Boolean, includeDstAttr: Boolean): VertexSetRDD[Array[Pid]] =
+    (includeSrcAttr, includeDstAttr) match {
+      case (true, true) => bothAttrs
+      case (true, false) => srcAttrOnly
+      case (false, true) => dstAttrOnly
+      case (false, false) => noAttrs
+    }
 
   def persist(newLevel: StorageLevel) {
     bothAttrs.persist(newLevel)
@@ -28,15 +36,17 @@ class Vid2Pid(
   }
 
   private def createVid2Pid(
-    includeSrcAttr: Boolean,
-    includeDstAttr: Boolean): VertexSetRDD[Array[Pid]] = {
+      includeSrcAttr: Boolean,
+      includeDstAttr: Boolean): VertexSetRDD[Array[Pid]] = {
     val preAgg = eTable.mapPartitions { iter =>
       val (pid, edgePartition) = iter.next()
       val vSet = new VertexSet
-      edgePartition.foreach(e => {
-        if (includeSrcAttr) vSet.add(e.srcId)
-        if (includeDstAttr) vSet.add(e.dstId)
-      })
+      if (includeSrcAttr || includeDstAttr) {
+        edgePartition.foreach(e => {
+          if (includeSrcAttr) vSet.add(e.srcId)
+          if (includeDstAttr) vSet.add(e.dstId)
+        })
+      }
       vSet.iterator.map { vid => (vid.toLong, pid) }
     }
     VertexSetRDD[Pid, ArrayBuffer[Pid]](preAgg, vTableIndex,

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -33,6 +33,18 @@ class GraphSuite extends FunSuite with LocalSparkContext {
     }
   }
 
+  test("mapReduceTriplets") {
+    withSpark(new SparkContext("local", "test")) { sc =>
+      val n = 3
+      val star = Graph(sc.parallelize((1 to n).map(x => (0: Vid, x: Vid))))
+
+      val neighborDegreeSums = star.mapReduceTriplets(
+        edge => Array((edge.srcId, edge.dstAttr), (edge.dstId, edge.srcAttr)),
+        (a: Int, b: Int) => a + b)
+      assert(neighborDegreeSums.collect().toSet === (0 to n).map(x => (x, n)).toSet)
+    }
+  }
+
   test("aggregateNeighbors") {
     withSpark(new SparkContext("local", "test")) { sc =>
       val n = 3

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -58,44 +58,6 @@ class GraphSuite extends FunSuite with LocalSparkContext {
     }
   }
 
-  test("aggregateNeighbors - source attribute replication only") {
-    withSpark(new SparkContext("local", "test")) { sc =>
-      val n = 3
-      // Create a star graph where the degree of each vertex is its attribute
-      val star = Graph(sc.parallelize((1 to n).map(x => ((n + 1): Vid, x: Vid))))
-
-      val totalOfInNeighborDegrees = star.aggregateNeighbors(
-        (vid, edge) => {
-          // All edges have the center vertex as the source, which has degree n
-          if (edge.srcAttr != n) {
-            throw new Exception("edge.srcAttr is %d, expected %d".format(edge.srcAttr, n))
-          }
-          Some(edge.srcAttr)
-        },
-        (a: Int, b: Int) => a + b,
-        EdgeDirection.In)
-      assert(totalOfInNeighborDegrees.collect().toSet === (1 to n).map(x => (x, n)).toSet)
-    }
-  }
-
-  test("aggregateNeighbors - no vertex attribute replication") {
-    withSpark(new SparkContext("local[2]", "test")) { sc =>
-      val n = 3
-      // Not serializable because it captures org.scalatest.Engine
-      class UnserializableAttribute {}
-      // Create a star graph where vertex attributes are not serializable
-      val star = Graph(sc.parallelize((1 to n).map(x => (0: Vid, x: Vid))))
-        .mapVertices { (id, attr) => new UnserializableAttribute }
-
-      // Should not serialize any vertex attributes
-      val ignoreAttributes = star.aggregateNeighbors(
-        (vid, edge) => Some(0),
-        (a: Int, b: Int) => a + b,
-        EdgeDirection.In)
-      assert(ignoreAttributes.collect().toSet === (1 to n).map(x => (x, 0)).toSet)
-    }
-  }
-
   test("joinVertices") {
     withSpark(new SparkContext("local", "test")) { sc =>
       val vertices = sc.parallelize(Seq[(Vid, String)]((1, "one"), (2, "two"), (3, "three")), 2)


### PR DESCRIPTION
Vertex attributes were previously replicated in row format using MessageToPartition. This pull request instead replicates them in column format by grouping together all attributes being sent from a vertex partition to an edge partition.

Performance comparison for 20 iterations of PageRank on LiveJournal:

| Commit | Comm. per shuffle | Runtime |
| --- | --- | --- |
| 6ee05be1c83768d50bff72f63f3a9c533c18e8c8 (master before #60) | 1675 MB | 484 +/- 6.5 s |
| 1a06f707e358055a2126a71bc77f235a181c225d (master after #60) | 1629 MB | 244 +/- 8.0 s |
| 53d24a973e7bd71d1509a326f0f12376a252f1db (aggregateNeighbors-variants) | 1238 MB | 160 +/- 7.7 s |
| **d1ff1b722274de8e03938452d8155f2a26c55f96 (pid2vid)** | **1123 MB** | **148 +/- 4.6 s** |
| 3c0995dbbc7266bb90d1add75ee4820a6b385b10 (Bagel) |  | 207 +/- 14 s |

**Depends on #55. Incremental diff: https://github.com/ankurdave/graphx/compare/aggregateNeighbors-variants...pid2vid**

Resolves #31.
