### PR TITLE
Removed sleep from pagerank in Analytics

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
@@ -295,8 +295,6 @@ object Analytics extends Logging {
          }
          logInfo("GRAPHX: Runtime:    " + ((System.currentTimeMillis - startTime)/1000.0) + " seconds")
 
-
-         Thread.sleep(1000000)
          sc.stop()
        }
 


### PR DESCRIPTION
Remove the `Thread.sleep(1000000)` that got introduced in https://github.com/amplab/graphx/commit/1e5c17812de073dd7fe890b99f921489895dae59#diff-392ec449b4f79b355d0789bf62cfb253R289
