### PR TITLE
Improve code readability

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
@@ -158,7 +158,7 @@ class OpenHashSet[@specialized(Long, Int) T: ClassManifest](
   /** Return the value at the specified position. */
   def getValue(pos: Int): T = _data(pos)
 
-  def iterator() = new Iterator[T] {
+  def iterator = new Iterator[T] {
     var pos = nextPos(0)
     override def hasNext: Boolean = pos != INVALID_POS
     override def next(): T = {

--- a/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
@@ -229,7 +229,7 @@ object Analytics extends Logging {
 
     // Construct set representations of the neighborhoods
     val nbrSets: VertexSetRDD[VertexSet] =
-      graph.collectNeighborIds(EdgeDirection.Both).mapValuesWithKeys { (vid, nbrs) =>
+      graph.collectNeighborIds(EdgeDirection.Both).mapValues { (vid, nbrs) =>
       val set = new VertexSet(4)
       var i = 0
       while (i < nbrs.size) {
@@ -254,7 +254,7 @@ object Analytics extends Logging {
       } else {
         (et.dstAttr, et.srcAttr)
       }
-      val iter = smallSet.iterator()
+      val iter = smallSet.iterator
       var counter: Int = 0
       while (iter.hasNext) {
         val vid = iter.next

--- a/graph/src/main/scala/org/apache/spark/graph/Graph.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Graph.scala
@@ -1,7 +1,9 @@
 package org.apache.spark.graph
 
+import org.apache.spark.graph.impl._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
+
 
 /**
  * The Graph abstractly represents a graph with arbitrary objects
@@ -162,7 +164,6 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
    * Construct a new graph with all the edges reversed.  If this graph
    * contains an edge from a to b then the returned graph contains an
    * edge from b to a.
-   *
    */
   def reverse: Graph[VD, ED]
 
@@ -292,9 +293,6 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
  */
 object Graph {
 
-  import org.apache.spark.graph.impl._
-  import org.apache.spark.SparkContext._
-
   /**
    * Construct a graph from a collection of edges encoded as vertex id pairs.
    *
@@ -324,15 +322,10 @@ object Graph {
       rawEdges: RDD[(Vid, Vid)],
       defaultValue: VD,
       uniqueEdges: Boolean,
-      partitionStrategy: PartitionStrategy):
-    Graph[VD, Int] = {
+      partitionStrategy: PartitionStrategy): Graph[VD, Int] = {
     val edges = rawEdges.map(p => Edge(p._1, p._2, 1))
     val graph = GraphImpl(edges, defaultValue, partitionStrategy)
-    if (uniqueEdges) {
-      graph.groupEdges((a,b) => a+b)
-    } else {
-      graph
-    }
+    if (uniqueEdges) graph.groupEdges((a, b) => a + b) else graph
   }
 
   /**
@@ -344,9 +337,8 @@ object Graph {
    * @return a graph with edge attributes described by `edges` and vertices
    *         given by all vertices in `edges` with value `defaultValue`
    */
-  def apply[VD: ClassManifest, ED: ClassManifest](
-      edges: RDD[Edge[ED]],
-      defaultValue: VD): Graph[VD, ED] = {
+  def apply[VD: ClassManifest, ED: ClassManifest](edges: RDD[Edge[ED]], defaultValue: VD)
+    : Graph[VD, ED] = {
     Graph(edges, defaultValue, RandomVertexCut())
   }
 

--- a/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
@@ -5,13 +5,12 @@ import com.esotericsoftware.kryo.Kryo
 import org.apache.spark.graph.impl._
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.spark.util.collection.BitSet
-import org.apache.spark.graph._
+
 
 class GraphKryoRegistrator extends KryoRegistrator {
 
   def registerClasses(kryo: Kryo) {
     kryo.register(classOf[Edge[Object]])
-    kryo.register(classOf[MutableTuple2[Object, Object]])
     kryo.register(classOf[MessageToPartition[Object]])
     kryo.register(classOf[VertexBroadcastMsg[Object]])
     kryo.register(classOf[AggregationMsg[Object]])

--- a/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartitionBuilder.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartitionBuilder.scala
@@ -1,27 +1,24 @@
 package org.apache.spark.graph.impl
 
-import scala.collection.mutable.ArrayBuilder
 import org.apache.spark.graph._
+import org.apache.spark.util.collection.PrimitiveVector
 
 
 //private[graph]
-class EdgePartitionBuilder[@specialized(Char, Int, Boolean, Byte, Long, Float, Double)
-ED: ClassManifest]{
-  val srcIds = new VertexArrayList
-  val dstIds = new VertexArrayList
-  var dataBuilder = ArrayBuilder.make[ED]
+class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassManifest] {
 
+  val srcIds = new PrimitiveVector[Vid]
+  val dstIds = new PrimitiveVector[Vid]
+  var dataBuilder = new PrimitiveVector[ED]
 
   /** Add a new edge to the partition. */
   def add(src: Vid, dst: Vid, d: ED) {
-    srcIds.add(src)
-    dstIds.add(dst)
+    srcIds += src
+    dstIds += dst
     dataBuilder += d
   }
 
   def toEdgePartition: EdgePartition[ED] = {
-    new EdgePartition(srcIds.toLongArray(), dstIds.toLongArray(), dataBuilder.result())
+    new EdgePartition(srcIds.trim().array, dstIds.trim().array, dataBuilder.trim().array)
   }
-
-
 }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/EdgeTripletIterator.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/EdgeTripletIterator.scala
@@ -1,0 +1,60 @@
+package org.apache.spark.graph.impl
+
+import scala.collection.mutable
+
+import org.apache.spark.graph._
+import org.apache.spark.util.collection.PrimitiveKeyOpenHashMap
+
+
+/**
+ * The Iterator type returned when constructing edge triplets. This class technically could be
+ * an anonymous class in GraphImpl.triplets, but we name it here explicitly so it is easier to
+ * debug / profile.
+ */
+private[impl]
+class EdgeTripletIterator[VD: ClassManifest, ED: ClassManifest](
+    val vidToIndex: VertexIdToIndexMap,
+    val vertexArray: Array[VD],
+    val edgePartition: EdgePartition[ED])
+  extends Iterator[EdgeTriplet[VD, ED]] {
+
+  // Current position in the array.
+  private var pos = 0
+
+  // A triplet object that this iterator.next() call returns. We reuse this object to avoid
+  // allocating too many temporary Java objects.
+  private val triplet = new EdgeTriplet[VD, ED]
+
+  private val vmap = new PrimitiveKeyOpenHashMap[Vid, VD](vidToIndex, vertexArray)
+
+  override def hasNext: Boolean = pos < edgePartition.size
+
+  override def next() = {
+    triplet.srcId = edgePartition.srcIds(pos)
+    // assert(vmap.containsKey(e.src.id))
+    triplet.srcAttr = vmap(triplet.srcId)
+    triplet.dstId = edgePartition.dstIds(pos)
+    // assert(vmap.containsKey(e.dst.id))
+    triplet.dstAttr = vmap(triplet.dstId)
+    triplet.attr = edgePartition.data(pos)
+    pos += 1
+    triplet
+  }
+
+  // TODO: Why do we need this?
+  override def toList: List[EdgeTriplet[VD, ED]] = {
+    val lb = new mutable.ListBuffer[EdgeTriplet[VD,ED]]
+    val currentEdge = new EdgeTriplet[VD, ED]
+    for (i <- 0 until edgePartition.size) {
+      currentEdge.srcId = edgePartition.srcIds(i)
+      // assert(vmap.containsKey(e.src.id))
+      currentEdge.srcAttr = vmap(currentEdge.srcId)
+      currentEdge.dstId = edgePartition.dstIds(i)
+      // assert(vmap.containsKey(e.dst.id))
+      currentEdge.dstAttr = vmap(currentEdge.dstId)
+      currentEdge.attr = edgePartition.data(i)
+      lb += currentEdge
+    }
+    lb.toList
+  }
+}

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -5,61 +5,60 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.util.collection.{OpenHashSet, PrimitiveKeyOpenHashMap}
 
 import org.apache.spark.graph._
-import org.apache.spark.graph.impl.MsgRDDFunctions._
 
 /**
  * Stores the vertex attribute values after they are replicated.
  */
+private[impl]
 class VTableReplicated[VD: ClassManifest](
     vTable: VertexSetRDD[VD],
     eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
     vertexPlacement: VertexPlacement) {
 
   val bothAttrs: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    VTableReplicated.createVTableReplicated(vTable, eTable, vertexPlacement, true, true)
+    createVTableReplicated(vTable, eTable, vertexPlacement, true, true)
+
   val srcAttrOnly: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    VTableReplicated.createVTableReplicated(vTable, eTable, vertexPlacement, true, false)
+    createVTableReplicated(vTable, eTable, vertexPlacement, true, false)
+
   val dstAttrOnly: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    VTableReplicated.createVTableReplicated(vTable, eTable, vertexPlacement, false, true)
+    createVTableReplicated(vTable, eTable, vertexPlacement, false, true)
+
   val noAttrs: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    VTableReplicated.createVTableReplicated(vTable, eTable, vertexPlacement, false, false)
+    createVTableReplicated(vTable, eTable, vertexPlacement, false, false)
 
-
-  def get(includeSrcAttr: Boolean, includeDstAttr: Boolean)
-    : RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    (includeSrcAttr, includeDstAttr) match {
+  def get(includeSrc: Boolean, includeDst: Boolean): RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] = {
+    (includeSrc, includeDst) match {
       case (true, true) => bothAttrs
       case (true, false) => srcAttrOnly
       case (false, true) => dstAttrOnly
       case (false, false) => noAttrs
     }
-}
+  }
 
-class VertexAttributeBlock[VD: ClassManifest](val vids: Array[Vid], val attrs: Array[VD])
+  private def createVTableReplicated[VD: ClassManifest](
+       vTable: VertexSetRDD[VD],
+       eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
+       vertexPlacement: VertexPlacement,
+       includeSrcAttr: Boolean,
+       includeDstAttr: Boolean): RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] = {
 
-object VTableReplicated {
-  protected def createVTableReplicated[VD: ClassManifest](
-      vTable: VertexSetRDD[VD],
-      eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
-      vertexPlacement: VertexPlacement,
-      includeSrcAttr: Boolean,
-      includeDstAttr: Boolean): RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] = {
     val placement = vertexPlacement.get(includeSrcAttr, includeDstAttr)
 
     // Send each edge partition the vertex attributes it wants, as specified in
     // vertexPlacement
     val msgsByPartition = placement.zipPartitions(vTable.partitionsRDD) {
       (pid2vidIter, vertexPartIter) =>
-      val pid2vid = pid2vidIter.next()
-      val vertexPart = vertexPartIter.next()
+        val pid2vid = pid2vidIter.next()
+        val vertexPart = vertexPartIter.next()
 
-      val vmap = new PrimitiveKeyOpenHashMap(vertexPart.index, vertexPart.values)
-      val output = new Array[(Pid, VertexAttributeBlock[VD])](pid2vid.size)
-      for (pid <- 0 until pid2vid.size) {
-        val block = new VertexAttributeBlock(pid2vid(pid), pid2vid(pid).map(vid => vmap(vid)))
-        output(pid) = (pid, block)
-      }
-      output.iterator
+        val vmap = new PrimitiveKeyOpenHashMap(vertexPart.index, vertexPart.values)
+        val output = new Array[(Pid, VertexAttributeBlock[VD])](pid2vid.size)
+        for (pid <- 0 until pid2vid.size) {
+          val block = new VertexAttributeBlock(pid2vid(pid), pid2vid(pid).map(vid => vmap(vid)))
+          output(pid) = (pid, block)
+        }
+        output.iterator
     }.partitionBy(eTable.partitioner.get).cache()
 
     // Within each edge partition, create a local map from vid to an index into
@@ -81,20 +80,22 @@ object VTableReplicated {
     // msgsByPartition into the correct locations specified in localVidMap
     localVidMap.zipPartitions(msgsByPartition) {
       (mapIter, msgsIter) =>
-      val (pid, vidToIndex) = mapIter.next()
-      assert(!mapIter.hasNext)
-      // Populate the vertex array using the vidToIndex map
-      val vertexArray = new Array[VD](vidToIndex.capacity)
-      for ((_, block) <- msgsIter) {
-        for (i <- 0 until block.vids.size) {
-          val vid = block.vids(i)
-          val attr = block.attrs(i)
-          val ind = vidToIndex.getPos(vid) & OpenHashSet.POSITION_MASK
-          vertexArray(ind) = attr
+        val (pid, vidToIndex) = mapIter.next()
+        assert(!mapIter.hasNext)
+        // Populate the vertex array using the vidToIndex map
+        val vertexArray = new Array[VD](vidToIndex.capacity)
+        for ((_, block) <- msgsIter) {
+          for (i <- 0 until block.vids.size) {
+            val vid = block.vids(i)
+            val attr = block.attrs(i)
+            val ind = vidToIndex.getPos(vid) & OpenHashSet.POSITION_MASK
+            vertexArray(ind) = attr
+          }
         }
-      }
-      Iterator((pid, (vidToIndex, vertexArray)))
+        Iterator((pid, (vidToIndex, vertexArray)))
     }.cache()
   }
 
 }
+
+class VertexAttributeBlock[VD: ClassManifest](val vids: Array[Vid], val attrs: Array[VD])

--- a/graph/src/main/scala/org/apache/spark/graph/package.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/package.scala
@@ -6,10 +6,11 @@ import org.apache.spark.util.collection.OpenHashSet
 package object graph {
 
   type Vid = Long
+
+  // TODO: Consider using Char.
   type Pid = Int
 
   type VertexSet = OpenHashSet[Vid]
-  type VertexArrayList = it.unimi.dsi.fastutil.longs.LongArrayList
 
   //  type VertexIdToIndexMap = it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap
   type VertexIdToIndexMap = OpenHashSet[Vid]
@@ -18,11 +19,4 @@ package object graph {
    * Return the default null-like value for a data type T.
    */
   def nullValue[T] = null.asInstanceOf[T]
-
-
-  private[graph]
-  case class MutableTuple2[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) U,
-                           @specialized(Char, Int, Boolean, Byte, Long, Float, Double) V](
-    var _1: U, var _2: V)
-
 }


### PR DESCRIPTION
There are lots of small changes throughout the code base. The biggest change is probably moving the implementation of mapReduceTriplets and mapTriplets back to GraphImpl class itself (instead of in GraphImpl object).

I left some questions as TODOs in the code. Ankur, Dan, Joey - please take a look at those TODOs. 

On top of this pull request, I think there are two or three ways to improve substantially the modularity and readability of the code base:
1. Explicitly name the apply functions. I felt we are slightly abusing apply's here.
2. Encapsulate the specific implementations and data structures used in VertexPartition by defining more methods in VertexPartition. Basically VertexSetRDD and GraphImpl shouldn't need to know the data structures (e.g. mask, bit set, values array).
3. (not sure if this one is doable - but I feel yes so far) remove the reference to VertexSetIndex, and for all operations that require an existing index, we add a method in VertexSetRDD to implement those (rather than taking an "index" out of VertexSetRDD and use another apply in VertexSetRDD to create a new VertexSetRDD with the index). 
