### PR TITLE
Codebase refactoring

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -245,7 +245,7 @@ class PairRDDFunctions[K: ClassManifest, V: ClassManifest](self: RDD[(K, V)])
     if (getKeyClass().isArray && partitioner.isInstanceOf[HashPartitioner]) {
       throw new SparkException("Default partitioner cannot partition array keys.")
     }
-    new ShuffledRDD[K, V, (K, V)](self, partitioner)
+    if (self.partitioner == partitioner) self else new ShuffledRDD[K, V, (K, V)](self, partitioner)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
@@ -158,7 +158,7 @@ class OpenHashSet[@specialized(Long, Int) T: ClassManifest](
   /** Return the value at the specified position. */
   def getValue(pos: Int): T = _data(pos)
 
-  def iterator() = new Iterator[T] {
+  def iterator = new Iterator[T] {
     var pos = nextPos(0)
     override def hasNext: Boolean = pos != INVALID_POS
     override def next(): T = {

--- a/core/src/main/scala/org/apache/spark/util/collection/PrimitiveKeyOpenHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PrimitiveKeyOpenHashMap.scala
@@ -71,7 +71,7 @@ class PrimitiveKeyOpenHashMap[@specialized(Long, Int) K: ClassManifest,
 
 
   /** Set the value for a key */
-  def setMerge(k: K, v: V, mergeF: (V,V) => V) {
+  def setMerge(k: K, v: V, mergeF: (V, V) => V) {
     val pos = keySet.addWithoutResize(k)
     val ind = pos & OpenHashSet.POSITION_MASK
     if ((pos & OpenHashSet.NONEXISTENCE_MASK) != 0) { // if first add

--- a/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
@@ -229,7 +229,7 @@ object Analytics extends Logging {
 
     // Construct set representations of the neighborhoods
     val nbrSets: VertexSetRDD[VertexSet] =
-      graph.collectNeighborIds(EdgeDirection.Both).mapValuesWithKeys { (vid, nbrs) =>
+      graph.collectNeighborIds(EdgeDirection.Both).mapValues { (vid, nbrs) =>
       val set = new VertexSet(4)
       var i = 0
       while (i < nbrs.size) {
@@ -254,7 +254,7 @@ object Analytics extends Logging {
       } else {
         (et.dstAttr, et.srcAttr)
       }
-      val iter = smallSet.iterator()
+      val iter = smallSet.iterator
       var counter: Int = 0
       while (iter.hasNext) {
         val vid = iter.next

--- a/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
@@ -301,10 +301,10 @@ object Analytics extends Logging {
 
     def pickPartitioner(v: String): PartitionStrategy = {
       v match {
-         case "RandomVertexCut" => RandomVertexCut()
-         case "EdgePartition1D" => EdgePartition1D()
-         case "EdgePartition2D" => EdgePartition2D()
-         case "CanonicalRandomVertexCut" => CanonicalRandomVertexCut()
+         case "RandomVertexCut" => RandomVertexCut
+         case "EdgePartition1D" => EdgePartition1D
+         case "EdgePartition2D" => EdgePartition2D
+         case "CanonicalRandomVertexCut" => CanonicalRandomVertexCut
          case _ => throw new IllegalArgumentException("Invalid Partition Strategy: " + v)
        }
     }
@@ -324,7 +324,7 @@ object Analytics extends Logging {
          var outFname = ""
          var numVPart = 4
          var numEPart = 4
-         var partitionStrategy: PartitionStrategy = RandomVertexCut()
+         var partitionStrategy: PartitionStrategy = RandomVertexCut
 
          options.foreach{
            case ("numIter", v) => numIter = v.toInt
@@ -379,7 +379,7 @@ object Analytics extends Logging {
            var numVPart = 4
            var numEPart = 4
            var isDynamic = false
-           var partitionStrategy: PartitionStrategy = RandomVertexCut()
+           var partitionStrategy: PartitionStrategy = RandomVertexCut
 
            options.foreach{
              case ("numIter", v) => numIter = v.toInt
@@ -413,7 +413,7 @@ object Analytics extends Logging {
        case "triangles" => {
          var numVPart = 4
          var numEPart = 4
-         var partitionStrategy: PartitionStrategy = RandomVertexCut()
+         var partitionStrategy: PartitionStrategy = RandomVertexCut
 
          options.foreach{
            case ("numEPart", v) => numEPart = v.toInt

--- a/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
@@ -228,7 +228,7 @@ object Analytics extends Logging {
     val graph = rawGraph.groupEdges( (a,b) => a ).cache
 
     // Construct set representations of the neighborhoods
-    val nbrSets: VertexSetRDD[VertexSet] =
+    val nbrSets: VertexRDD[VertexSet] =
       graph.collectNeighborIds(EdgeDirection.Both).mapValues { (vid, nbrs) =>
       val set = new VertexSet(4)
       var i = 0
@@ -263,7 +263,7 @@ object Analytics extends Logging {
       Iterator((et.srcId, counter), (et.dstId, counter))
     }
     // compute the intersection along edges
-    val counters: VertexSetRDD[Int] = setGraph.mapReduceTriplets(edgeFunc, _ + _)
+    val counters: VertexRDD[Int] = setGraph.mapReduceTriplets(edgeFunc, _ + _)
     // Merge counters with the graph and divide by two since each triangle is counted twice
     graph.outerJoinVertices(counters) {
       (vid, _, optCounter: Option[Int]) =>

--- a/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
@@ -92,19 +92,21 @@ object Analytics extends Logging {
           minEdgePartitions = numEPart, partitionStrategy=partitionStrategy).cache()
 
          val startTime = System.currentTimeMillis
-         logInfo("GRAPHX: starting tasks")
-         logInfo("GRAPHX: Number of vertices " + graph.vertices.count)
-         logInfo("GRAPHX: Number of edges " + graph.edges.count)
+         println("GRAPHX: starting tasks")
+         println("GRAPHX: Number of vertices " + graph.vertices.count)
+         println("GRAPHX: Number of edges " + graph.edges.count)
 
          //val pr = Analytics.pagerank(graph, numIter)
           val pr = if(isDynamic) PageRank.runUntillConvergence(graph, tol, numIter)
             else  PageRank.run(graph, numIter)
-         logInfo("GRAPHX: Total rank: " + pr.vertices.map{ case (id,r) => r }.reduce(_+_) )
+         println("GRAPHX: Total rank: " + pr.vertices.map{ case (id,r) => r }.reduce(_+_) )
          if (!outFname.isEmpty) {
            println("Saving pageranks of pages to " + outFname)
            pr.vertices.map{case (id, r) => id + "\t" + r}.saveAsTextFile(outFname)
          }
-         logInfo("GRAPHX: Runtime:    " + ((System.currentTimeMillis - startTime)/1000.0) + " seconds")
+         println("GRAPHX: Runtime: " + ((System.currentTimeMillis - startTime)/1000.0) + " seconds")
+
+         Thread.sleep(100000)
 
          sc.stop()
        }

--- a/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Analytics.scala
@@ -1,6 +1,8 @@
 package org.apache.spark.graph
 
 import org.apache.spark._
+import org.apache.spark.graph.algorithms._
+
 
 /**
  * The Analytics object contains a collection of basic graph analytics
@@ -11,272 +13,6 @@ import org.apache.spark._
  * formats.
  */
 object Analytics extends Logging {
-
-  /**
-   * Run PageRank for a fixed number of iterations returning a graph
-   * with vertex attributes containing the PageRank and edge
-   * attributes the normalized edge weight.
-   *
-   * The following PageRank fixed point is computed for each vertex.
-   *
-   * {{{
-   * var PR = Array.fill(n)( 1.0 )
-   * val oldPR = Array.fill(n)( 1.0 )
-   * for( iter <- 0 until numIter ) {
-   *   swap(oldPR, PR)
-   *   for( i <- 0 until n ) {
-   *     PR[i] = alpha + (1 - alpha) * inNbrs[i].map(j => oldPR[j] / outDeg[j]).sum
-   *   }
-   * }
-   * }}}
-   *
-   * where `alpha` is the random reset probability (typically 0.15),
-   * `inNbrs[i]` is the set of neighbors whick link to `i` and
-   * `outDeg[j]` is the out degree of vertex `j`.
-   *
-   * Note that this is not the "normalized" PageRank and as a
-   * consequence pages that have no inlinks will have a PageRank of
-   * alpha.
-   *
-   * @tparam VD the original vertex attribute (not used)
-   * @tparam ED the original edge attribute (not used)
-   *
-   * @param graph the graph on which to compute PageRank
-   * @param numIter the number of iterations of PageRank to run
-   * @param resetProb the random reset probability (alpha)
-   *
-   * @return the graph containing with each vertex containing the
-   * PageRank and each edge containing the normalized weight.
-   *
-   */
-  def pagerank[VD: Manifest, ED: Manifest](
-    graph: Graph[VD, ED], numIter: Int, resetProb: Double = 0.15):
-    Graph[Double, Double] = {
-
-    /**
-     * Initialize the pagerankGraph with each edge attribute having
-     * weight 1/outDegree and each vertex with attribute 1.0.
-     */
-    val pagerankGraph: Graph[Double, Double] = graph
-      // Associate the degree with each vertex
-      .outerJoinVertices(graph.outDegrees){
-        (vid, vdata, deg) => deg.getOrElse(0)
-      }
-      // Set the weight on the edges based on the degree
-      .mapTriplets( e => 1.0 / e.srcAttr )
-      // Set the vertex attributes to the initial pagerank values
-      .mapVertices( (id, attr) => 1.0 )
-
-    // Display statistics about pagerank
-    println(pagerankGraph.statistics)
-
-    // Define the three functions needed to implement PageRank in the GraphX
-    // version of Pregel
-    def vertexProgram(id: Vid, attr: Double, msgSum: Double): Double =
-      resetProb + (1.0 - resetProb) * msgSum
-    def sendMessage(edge: EdgeTriplet[Double, Double]) =
-      Iterator((edge.dstId, edge.srcAttr * edge.attr))
-    def messageCombiner(a: Double, b: Double): Double = a + b
-    // The initial message received by all vertices in PageRank
-    val initialMessage = 0.0
-
-    // Execute pregel for a fixed number of iterations.
-    Pregel(pagerankGraph, initialMessage, numIter)(
-      vertexProgram, sendMessage, messageCombiner)
-  }
-
-
-  /**
-   * Run a dynamic version of PageRank returning a graph with vertex
-   * attributes containing the PageRank and edge attributes containing
-   * the normalized edge weight.
-   *
-   * {{{
-   * var PR = Array.fill(n)( 1.0 )
-   * val oldPR = Array.fill(n)( 0.0 )
-   * while( max(abs(PR - oldPr)) > tol ) {
-   *   swap(oldPR, PR)
-   *   for( i <- 0 until n if abs(PR[i] - oldPR[i]) > tol ) {
-   *     PR[i] = alpha + (1 - \alpha) * inNbrs[i].map(j => oldPR[j] / outDeg[j]).sum
-   *   }
-   * }
-   * }}}
-   *
-   * where `alpha` is the random reset probability (typically 0.15),
-   * `inNbrs[i]` is the set of neighbors whick link to `i` and
-   * `outDeg[j]` is the out degree of vertex `j`.
-   *
-   * Note that this is not the "normalized" PageRank and as a
-   * consequence pages that have no inlinks will have a PageRank of
-   * alpha.
-   *
-   * @tparam VD the original vertex attribute (not used)
-   * @tparam ED the original edge attribute (not used)
-   *
-   * @param graph the graph on which to compute PageRank
-   * @param tol the tolerance allowed at convergence (smaller => more
-   * accurate).
-   * @param resetProb the random reset probability (alpha)
-   *
-   * @return the graph containing with each vertex containing the
-   * PageRank and each edge containing the normalized weight.
-   */
-  def deltaPagerank[VD: Manifest, ED: Manifest](
-    graph: Graph[VD, ED], tol: Double, resetProb: Double = 0.15):
-    Graph[Double, Double] = {
-
-    /**
-     * Initialize the pagerankGraph with each edge attribute
-     * having weight 1/outDegree and each vertex with attribute 1.0.
-     */
-    val pagerankGraph: Graph[(Double, Double), Double] = graph
-      // Associate the degree with each vertex
-      .outerJoinVertices(graph.outDegrees){
-        (vid, vdata, deg) => deg.getOrElse(0)
-      }
-      // Set the weight on the edges based on the degree
-      .mapTriplets( e => 1.0 / e.srcAttr )
-      // Set the vertex attributes to (initalPR, delta = 0)
-      .mapVertices( (id, attr) => (0.0, 0.0) )
-
-    // Display statistics about pagerank
-    println(pagerankGraph.statistics)
-
-    // Define the three functions needed to implement PageRank in the GraphX
-    // version of Pregel
-    def vertexProgram(id: Vid, attr: (Double, Double), msgSum: Double): (Double, Double) = {
-      val (oldPR, lastDelta) = attr
-      val newPR = oldPR + (1.0 - resetProb) * msgSum
-      (newPR, newPR - oldPR)
-    }
-    def sendMessage(edge: EdgeTriplet[(Double, Double), Double]) = {
-      if (edge.srcAttr._2 > tol) {
-        Iterator((edge.dstId, edge.srcAttr._2 * edge.attr))
-      } else {
-        Iterator.empty
-      }
-    }
-    def messageCombiner(a: Double, b: Double): Double = a + b
-    // The initial message received by all vertices in PageRank
-    val initialMessage = resetProb / (1.0 - resetProb)
-
-    // Execute a dynamic version of Pregel.
-    Pregel(pagerankGraph, initialMessage)(
-      vertexProgram, sendMessage, messageCombiner)
-      .mapVertices( (vid, attr) => attr._1 )
-  } // end of deltaPageRank
-
-
-  /**
-   * Compute the connected component membership of each vertex and
-   * return an RDD with the vertex value containing the lowest vertex
-   * id in the connected component containing that vertex.
-   *
-   * @tparam VD the vertex attribute type (discarded in the
-   * computation)
-   * @tparam ED the edge attribute type (preserved in the computation)
-   *
-   * @param graph the graph for which to compute the connected
-   * components
-   *
-   * @return a graph with vertex attributes containing the smallest
-   * vertex in each connected component
-   */
-  def connectedComponents[VD: Manifest, ED: Manifest](graph: Graph[VD, ED]):
-    Graph[Vid, ED] = {
-    val ccGraph = graph.mapVertices { case (vid, _) => vid }
-
-    def sendMessage(edge: EdgeTriplet[Vid, ED]) = {
-      if (edge.srcAttr < edge.dstAttr) {
-        Iterator((edge.dstId, edge.srcAttr))
-      } else if (edge.srcAttr > edge.dstAttr) {
-        Iterator((edge.srcId, edge.dstAttr))
-      } else {
-        Iterator.empty
-      }
-    }
-    val initialMessage = Long.MaxValue
-    Pregel(ccGraph, initialMessage)(
-      (id, attr, msg) => math.min(attr, msg),
-      sendMessage,
-      (a,b) => math.min(a,b)
-      )
-  } // end of connectedComponents
-
-
-  /**
-   * Compute the number of triangles passing through each vertex.
-   *
-   * The algorithm is relatively straightforward and can be computed in
-   * three steps:
-   *
-   * 1) Compute the set of neighbors for each vertex
-   * 2) For each edge compute the intersection of the sets and send the
-   *    count to both vertices.
-   * 3) Compute the sum at each vertex and divide by two since each
-   *    triangle is counted twice.
-   *
-   *
-   * @param graph a graph with `sourceId` less than `destId`
-   * @tparam VD
-   * @tparam ED
-   * @return
-   */
-  def triangleCount[VD: ClassManifest, ED: ClassManifest](rawGraph: Graph[VD,ED]):
-    Graph[Int, ED] = {
-    // Remove redundant edges
-    val graph = rawGraph.groupEdges( (a,b) => a ).cache
-
-    // Construct set representations of the neighborhoods
-    val nbrSets: VertexRDD[VertexSet] =
-      graph.collectNeighborIds(EdgeDirection.Both).mapValues { (vid, nbrs) =>
-      val set = new VertexSet(4)
-      var i = 0
-      while (i < nbrs.size) {
-        // prevent self cycle
-        if(nbrs(i) != vid) {
-          set.add(nbrs(i))
-        }
-        i += 1
-      }
-      set
-    }
-    // join the sets with the graph
-    val setGraph: Graph[VertexSet, ED] = graph.outerJoinVertices(nbrSets) {
-      (vid, _, optSet) => optSet.getOrElse(null)
-    }
-    // Edge function computes intersection of smaller vertex with larger vertex
-    def edgeFunc(et: EdgeTriplet[VertexSet, ED]): Iterator[(Vid, Int)] = {
-      assert(et.srcAttr != null)
-      assert(et.dstAttr != null)
-      val (smallSet, largeSet) = if (et.srcAttr.size < et.dstAttr.size) {
-        (et.srcAttr, et.dstAttr)
-      } else {
-        (et.dstAttr, et.srcAttr)
-      }
-      val iter = smallSet.iterator
-      var counter: Int = 0
-      while (iter.hasNext) {
-        val vid = iter.next
-        if (vid != et.srcId && vid != et.dstId && largeSet.contains(vid)) { counter += 1 }
-      }
-      Iterator((et.srcId, counter), (et.dstId, counter))
-    }
-    // compute the intersection along edges
-    val counters: VertexRDD[Int] = setGraph.mapReduceTriplets(edgeFunc, _ + _)
-    // Merge counters with the graph and divide by two since each triangle is counted twice
-    graph.outerJoinVertices(counters) {
-      (vid, _, optCounter: Option[Int]) =>
-      val dblCount = optCounter.getOrElse(0)
-      // double count should be even (divisible by two)
-      assert((dblCount & 1) == 0)
-      dblCount / 2
-    }
-
-  } // end of TriangleCount
-
-
-
 
   def main(args: Array[String]) = {
     val host = args(0)
@@ -361,8 +97,8 @@ object Analytics extends Logging {
          logInfo("GRAPHX: Number of edges " + graph.edges.count)
 
          //val pr = Analytics.pagerank(graph, numIter)
-          val pr = if(isDynamic) Analytics.deltaPagerank(graph, tol, numIter)
-            else  Analytics.pagerank(graph, numIter)
+          val pr = if(isDynamic) PageRank.runUntillConvergence(graph, tol, numIter)
+            else  PageRank.run(graph, numIter)
          logInfo("GRAPHX: Total rank: " + pr.vertices.map{ case (id,r) => r }.reduce(_+_) )
          if (!outFname.isEmpty) {
            println("Saving pageranks of pages to " + outFname)
@@ -405,7 +141,7 @@ object Analytics extends Logging {
            val sc = new SparkContext(host, "ConnectedComponents(" + fname + ")")
            val graph = GraphLoader.edgeListFile(sc, fname,
             minEdgePartitions = numEPart, partitionStrategy=partitionStrategy).cache()
-           val cc = Analytics.connectedComponents(graph)
+           val cc = ConnectedComponents.run(graph)
            println("Components: " + cc.vertices.map{ case (vid,data) => data}.distinct())
            sc.stop()
          }
@@ -427,7 +163,7 @@ object Analytics extends Logging {
          val sc = new SparkContext(host, "TriangleCount(" + fname + ")")
          val graph = GraphLoader.edgeListFile(sc, fname, canonicalOrientation = true,
            minEdgePartitions = numEPart, partitionStrategy=partitionStrategy).cache()
-         val triangles = Analytics.triangleCount(graph)
+         val triangles = TriangleCount.run(graph)
          println("Triangles: " + triangles.vertices.map {
             case (vid,data) => data.toLong
           }.reduce(_+_) / 3)
@@ -535,42 +271,6 @@ object Analytics extends Logging {
        }
      }
    }
-
-  // /**
-  //  * Compute the PageRank of a graph returning the pagerank of each vertex as an RDD
-  //  */
-  // def dynamicPagerank[VD: Manifest, ED: Manifest](graph: Graph[VD, ED],
-  //   tol: Double, maxIter: Int = 10) = {
-  //   // Compute the out degree of each vertex
-  //   val pagerankGraph = graph.updateVertices[Int, (Int, Double, Double)](graph.outDegrees,
-  //     (vertex, degIter) => (degIter.sum, 1.0, 1.0)
-  //   )
-
-  //   // Run PageRank
-  //   GraphLab.iterateGAS(pagerankGraph)(
-  //     (me_id, edge) => edge.src.data._2 / edge.src.data._1, // gather
-  //     (a: Double, b: Double) => a + b,
-  //     (vertex, a: Option[Double]) =>
-  //       (vertex.data._1, (0.15 + 0.85 * a.getOrElse(0.0)), vertex.data._2), // apply
-  //     (me_id, edge) => math.abs(edge.src.data._2 - edge.dst.data._1) > tol, // scatter
-  //     maxIter).mapVertices { case Vertex(vid, data) => Vertex(vid, data._2) }
-  // }
-
-  // /**
-  //  * Compute the connected component membership of each vertex
-  //  * and return an RDD with the vertex value containing the
-  //  * lowest vertex id in the connected component containing
-  //  * that vertex.
-  //  */
-  // def connectedComponents[VD: Manifest, ED: Manifest](graph: Graph[VD, ED], numIter: Int) = {
-  //   val ccGraph = graph.mapVertices { case Vertex(vid, _) => Vertex(vid, vid) }
-  //   GraphLab.iterateGA[Int, ED, Int](ccGraph)(
-  //     (me_id, edge) => edge.otherVertex(me_id).data, // gather
-  //     (a: Int, b: Int) => math.min(a, b), // merge
-  //     (v, a: Option[Int]) => math.min(v.data, a.getOrElse(Integer.MAX_VALUE)), // apply
-  //     numIter,
-  //     gatherDirection = EdgeDirection.Both)
-  // }
 
   // /**
   //  * Compute the shortest path to a set of markers

--- a/graph/src/main/scala/org/apache/spark/graph/Edge.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Edge.scala
@@ -30,7 +30,6 @@ case class Edge[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) ED] 
   def otherVertexId(vid: Vid): Vid =
     if (srcId == vid) dstId else { assert(dstId == vid); srcId }
 
-
   /**
    * Return the relative direction of the edge to the corresponding
    * vertex.
@@ -41,5 +40,4 @@ case class Edge[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) ED] 
    */
   def relativeDirection(vid: Vid): EdgeDirection =
     if (vid == srcId) EdgeDirection.Out else { assert(vid == dstId); EdgeDirection.In }
-
 }

--- a/graph/src/main/scala/org/apache/spark/graph/Edge.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Edge.scala
@@ -18,7 +18,7 @@ case class Edge[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) ED] 
   var dstId: Vid = 0,
   /**
    * The attribute associated with the edge.
-   */ 
+   */
   var attr: ED = nullValue[ED]) {
 
   /**

--- a/graph/src/main/scala/org/apache/spark/graph/EdgeRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/EdgeRDD.scala
@@ -1,0 +1,58 @@
+package org.apache.spark.graph
+
+
+import org.apache.spark.{TaskContext, Partition, OneToOneDependency}
+import org.apache.spark.graph.impl.EdgePartition
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+
+
+class EdgeRDD[@specialized ED: ClassManifest](
+    val partitionsRDD: RDD[(Pid, EdgePartition[ED])])
+  extends RDD[Edge[ED]](partitionsRDD.context, List(new OneToOneDependency(partitionsRDD))) {
+
+  override val partitioner = partitionsRDD.partitioner
+
+  override protected def getPartitions: Array[Partition] = partitionsRDD.partitions
+
+  override def compute(split: Partition, context: TaskContext): Iterator[Edge[ED]] = {
+    val edgePartition = partitionsRDD.compute(split, context).next()._2
+    edgePartition.iterator
+  }
+
+  override def collect(): Array[Edge[ED]] = this.map(_.copy()).collect()
+
+  /**
+   * Caching a VertexRDD causes the index and values to be cached separately.
+   */
+  override def persist(newLevel: StorageLevel): EdgeRDD[ED] = {
+    partitionsRDD.persist(newLevel)
+    this
+  }
+
+  /** Persist this RDD with the default storage level (`MEMORY_ONLY`). */
+  override def persist(): EdgeRDD[ED] = persist(StorageLevel.MEMORY_ONLY)
+
+  /** Persist this RDD with the default storage level (`MEMORY_ONLY`). */
+  override def cache(): EdgeRDD[ED] = persist()
+
+  def mapEdgePartitions[ED2: ClassManifest](f: EdgePartition[ED] => EdgePartition[ED2])
+    : EdgeRDD[ED2]= {
+    val cleanF = sparkContext.clean(f)
+    new EdgeRDD[ED2](partitionsRDD.mapPartitions({ iter =>
+      val (pid, ep) = iter.next()
+      Iterator(Tuple2(pid, cleanF(ep)))
+    }, preservesPartitioning = true))
+  }
+
+  def zipEdgePartitions[T: ClassManifest, U: ClassManifest]
+      (other: RDD[T])
+      (f: (EdgePartition[ED], Iterator[T]) => Iterator[U]): RDD[U] = {
+    val cleanF = sparkContext.clean(f)
+    partitionsRDD.zipPartitions(other, preservesPartitioning = true) { (ePartIter, otherIter) =>
+      val (_, edgePartition) = ePartIter.next()
+      cleanF(edgePartition, otherIter)
+    }
+  }
+
+}

--- a/graph/src/main/scala/org/apache/spark/graph/EdgeTriplet.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/EdgeTriplet.scala
@@ -53,4 +53,6 @@ class EdgeTriplet[VD, ED] extends Edge[ED] {
    */
   def vertexAttr(vid: Vid): VD =
     if (srcId == vid) srcAttr else { assert(dstId == vid); dstAttr }
+
+  override def toString() = ((srcId, srcAttr), (dstId, dstAttr), attr).toString()
 }

--- a/graph/src/main/scala/org/apache/spark/graph/EdgeTriplet.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/EdgeTriplet.scala
@@ -53,5 +53,4 @@ class EdgeTriplet[VD, ED] extends Edge[ED] {
    */
   def vertexAttr(vid: Vid): VD =
     if (srcId == vid) srcAttr else { assert(dstId == vid); dstAttr }
-
 }

--- a/graph/src/main/scala/org/apache/spark/graph/Graph.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Graph.scala
@@ -1,7 +1,9 @@
 package org.apache.spark.graph
 
+import org.apache.spark.graph.impl._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
+
 
 /**
  * The Graph abstractly represents a graph with arbitrary objects
@@ -162,7 +164,6 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
    * Construct a new graph with all the edges reversed.  If this graph
    * contains an edge from a to b then the returned graph contains an
    * edge from b to a.
-   *
    */
   def reverse: Graph[VD, ED]
 
@@ -292,9 +293,6 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
  */
 object Graph {
 
-  import org.apache.spark.graph.impl._
-  import org.apache.spark.SparkContext._
-
   /**
    * Construct a graph from a collection of edges encoded as vertex id pairs.
    *
@@ -324,15 +322,10 @@ object Graph {
       rawEdges: RDD[(Vid, Vid)],
       defaultValue: VD,
       uniqueEdges: Boolean,
-      partitionStrategy: PartitionStrategy):
-    Graph[VD, Int] = {
+      partitionStrategy: PartitionStrategy): Graph[VD, Int] = {
     val edges = rawEdges.map(p => Edge(p._1, p._2, 1))
     val graph = GraphImpl(edges, defaultValue, partitionStrategy)
-    if (uniqueEdges) {
-      graph.groupEdges((a,b) => a+b)
-    } else {
-      graph
-    }
+    if (uniqueEdges) graph.groupEdges((a, b) => a + b) else graph
   }
 
   /**
@@ -344,9 +337,8 @@ object Graph {
    * @return a graph with edge attributes described by `edges` and vertices
    *         given by all vertices in `edges` with value `defaultValue`
    */
-  def apply[VD: ClassManifest, ED: ClassManifest](
-      edges: RDD[Edge[ED]],
-      defaultValue: VD): Graph[VD, ED] = {
+  def apply[VD: ClassManifest, ED: ClassManifest](edges: RDD[Edge[ED]], defaultValue: VD)
+    : Graph[VD, ED] = {
     Graph(edges, defaultValue, RandomVertexCut())
   }
 

--- a/graph/src/main/scala/org/apache/spark/graph/Graph.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Graph.scala
@@ -34,7 +34,7 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
    * @see Vertex for the vertex type.
    *
    */
-  val vertices: VertexSetRDD[VD]
+  val vertices: VertexRDD[VD]
 
   /**
    * Get the Edges and their data as an RDD.  The entries in the RDD
@@ -243,7 +243,7 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
   def mapReduceTriplets[A: ClassManifest](
       mapFunc: EdgeTriplet[VD, ED] => Iterator[(Vid, A)],
       reduceFunc: (A, A) => A)
-    : VertexSetRDD[A]
+    : VertexRDD[A]
 
   /**
    * Join the vertices with an RDD and then apply a function from the

--- a/graph/src/main/scala/org/apache/spark/graph/Graph.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Graph.scala
@@ -287,22 +287,9 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
 
 
 /**
- * The Graph object contains a collection of routines used to
- * construct graphs from RDDs.
- *
+ * The Graph object contains a collection of routines used to construct graphs from RDDs.
  */
 object Graph {
-
-  /**
-   * Construct a graph from a collection of edges encoded as vertex id pairs.
-   *
-   * @param rawEdges the RDD containing the set of edges in the graph
-   *
-   * @return a graph with edge attributes containing the count of duplicate edges.
-   */
-  def apply[VD: ClassManifest](rawEdges: RDD[(Vid, Vid)], defaultValue: VD): Graph[VD, Int] = {
-    Graph(rawEdges, defaultValue, false, RandomVertexCut())
-  }
 
   /**
    * Construct a graph from a collection of edges encoded as vertex id
@@ -316,13 +303,12 @@ object Graph {
    * @return a graph with edge attributes containing either the count
    * of duplicate edges or 1 (if `uniqueEdges=false`) and vertex
    * attributes containing the total degree of each vertex.
-   *
    */
-  def apply[VD: ClassManifest](
+  def fromEdgeTuples[VD: ClassManifest](
       rawEdges: RDD[(Vid, Vid)],
       defaultValue: VD,
-      uniqueEdges: Boolean,
-      partitionStrategy: PartitionStrategy): Graph[VD, Int] = {
+      uniqueEdges: Boolean = false,
+      partitionStrategy: PartitionStrategy = RandomVertexCut): Graph[VD, Int] = {
     val edges = rawEdges.map(p => Edge(p._1, p._2, 1))
     val graph = GraphImpl(edges, defaultValue, partitionStrategy)
     if (uniqueEdges) graph.groupEdges((a, b) => a + b) else graph
@@ -337,106 +323,42 @@ object Graph {
    * @return a graph with edge attributes described by `edges` and vertices
    *         given by all vertices in `edges` with value `defaultValue`
    */
-  def apply[VD: ClassManifest, ED: ClassManifest](edges: RDD[Edge[ED]], defaultValue: VD)
-    : Graph[VD, ED] = {
-    Graph(edges, defaultValue, RandomVertexCut())
-  }
-
-  /**
-   * Construct a graph from a collection of edges.
-   *
-   * @param edges the RDD containing the set of edges in the graph
-   * @param defaultValue the default vertex attribute to use for each vertex
-   *
-   * @return a graph with edge attributes described by `edges` and vertices
-   *         given by all vertices in `edges` with value `defaultValue`
-   */
-  def apply[VD: ClassManifest, ED: ClassManifest](
+  def fromEdges[VD: ClassManifest, ED: ClassManifest](
       edges: RDD[Edge[ED]],
       defaultValue: VD,
-      partitionStrategy: PartitionStrategy): Graph[VD, ED] = {
+      partitionStrategy: PartitionStrategy = RandomVertexCut): Graph[VD, ED] = {
     GraphImpl(edges, defaultValue, partitionStrategy)
   }
 
   /**
    * Construct a graph from a collection attributed vertices and
-   * edges.
-   *
-   * @note Duplicate vertices are removed arbitrarily and missing
-   * vertices (vertices in the edge collection that are not in the
-   * vertex collection) are replaced by null vertex attributes.
-   *
-   * @tparam VD the vertex attribute type
-   * @tparam ED the edge attribute type
-   * @param vertices the "set" of vertices and their attributes
-   * @param edges the collection of edges in the graph
-   *
-   */
-  def apply[VD: ClassManifest, ED: ClassManifest](
-      vertices: RDD[(Vid,VD)],
-      edges: RDD[Edge[ED]]): Graph[VD, ED] = {
-    val defaultAttr: VD = null.asInstanceOf[VD]
-    Graph(vertices, edges, defaultAttr, (a:VD,b:VD) => a, RandomVertexCut())
-  }
-
-  /**
-   * Construct a graph from a collection attributed vertices and
-   * edges.  Duplicate vertices are combined using the `mergeFunc` and
+   * edges.  Duplicate vertices are picked arbitrarily and
    * vertices found in the edge collection but not in the input
-   * vertices are the default attribute `defautVertexAttr`.
-   *
-   * @note Duplicate vertices are removed arbitrarily .
+   * vertices are the default attribute.
    *
    * @tparam VD the vertex attribute type
    * @tparam ED the edge attribute type
    * @param vertices the "set" of vertices and their attributes
    * @param edges the collection of edges in the graph
    * @param defaultVertexAttr the default vertex attribute to use for
-   * vertices that are mentioned in `edges` but not in `vertices`
-   *
-   */
-  def apply[VD: ClassManifest, ED: ClassManifest](
-      vertices: RDD[(Vid,VD)],
-      edges: RDD[Edge[ED]],
-      defaultVertexAttr: VD): Graph[VD, ED] = {
-    Graph(vertices, edges, defaultVertexAttr, (a,b) => a, RandomVertexCut())
-  }
-
-  /**
-   * Construct a graph from a collection attributed vertices and
-   * edges.  Duplicate vertices are combined using the `mergeFunc` and
-   * vertices found in the edge collection but not in the input
-   * vertices are the default attribute `defautVertexAttr`.
-   *
-   * @tparam VD the vertex attribute type
-   * @tparam ED the edge attribute type
-   * @param vertices the "set" of vertices and their attributes
-   * @param edges the collection of edges in the graph
-   * @param defaultVertexAttr the default vertex attribute to use for
-   * vertices that are mentioned in `edges` but not in `vertices
-   * @param mergeFunc the function used to merge duplicate vertices
-   * in the `vertices` collection.
+   * vertices that are mentioned in edges but not in vertices
    * @param partitionStrategy the partition strategy to use when
    * partitioning the edges.
-   *
    */
   def apply[VD: ClassManifest, ED: ClassManifest](
-      vertices: RDD[(Vid,VD)],
+      vertices: RDD[(Vid, VD)],
       edges: RDD[Edge[ED]],
-      defaultVertexAttr: VD,
-      mergeFunc: (VD, VD) => VD,
-      partitionStrategy: PartitionStrategy): Graph[VD, ED] = {
-    GraphImpl(vertices, edges, defaultVertexAttr, mergeFunc, partitionStrategy)
+      defaultVertexAttr: VD = null.asInstanceOf[VD],
+      partitionStrategy: PartitionStrategy = RandomVertexCut): Graph[VD, ED] = {
+    GraphImpl(vertices, edges, defaultVertexAttr, partitionStrategy)
   }
 
   /**
-   * The implicit graphToGraphOPs function extracts the GraphOps
-   * member from a graph.
+   * The implicit graphToGraphOPs function extracts the GraphOps member from a graph.
    *
-   * To improve modularity the Graph type only contains a small set of
-   * basic operations.  All the convenience operations are defined in
-   * the GraphOps class which may be shared across multiple graph
-   * implementations.
+   * To improve modularity the Graph type only contains a small set of basic operations.  All the
+   * convenience operations are defined in the GraphOps class which may be shared across multiple
+   * graph implementations.
    */
   implicit def graphToGraphOps[VD: ClassManifest, ED: ClassManifest](g: Graph[VD, ED]) = g.ops
 } // end of Graph object

--- a/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
@@ -5,13 +5,12 @@ import com.esotericsoftware.kryo.Kryo
 import org.apache.spark.graph.impl._
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.spark.util.collection.BitSet
-import org.apache.spark.graph._
+
 
 class GraphKryoRegistrator extends KryoRegistrator {
 
   def registerClasses(kryo: Kryo) {
     kryo.register(classOf[Edge[Object]])
-    kryo.register(classOf[MutableTuple2[Object, Object]])
     kryo.register(classOf[MessageToPartition[Object]])
     kryo.register(classOf[VertexBroadcastMsg[Object]])
     kryo.register(classOf[AggregationMsg[Object]])

--- a/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
@@ -13,7 +13,6 @@ class GraphKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[Edge[Object]])
     kryo.register(classOf[MessageToPartition[Object]])
     kryo.register(classOf[VertexBroadcastMsg[Object]])
-    kryo.register(classOf[AggregationMsg[Object]])
     kryo.register(classOf[(Vid, Object)])
     kryo.register(classOf[EdgePartition[Object]])
     kryo.register(classOf[BitSet])

--- a/graph/src/main/scala/org/apache/spark/graph/GraphLoader.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphLoader.scala
@@ -26,7 +26,7 @@ object GraphLoader {
       path: String,
       edgeParser: Array[String] => ED,
       minEdgePartitions: Int = 1,
-      partitionStrategy: PartitionStrategy = RandomVertexCut()):
+      partitionStrategy: PartitionStrategy = RandomVertexCut):
     Graph[Int, ED] = {
     // Parse the edge data table
     val edges = sc.textFile(path, minEdgePartitions).mapPartitions( iter =>
@@ -43,7 +43,7 @@ object GraphLoader {
         Edge(source, target, edata)
       })
     val defaultVertexAttr = 1
-    Graph(edges, defaultVertexAttr, partitionStrategy)
+    Graph.fromEdges(edges, defaultVertexAttr, partitionStrategy)
   }
 
   /**
@@ -78,7 +78,7 @@ object GraphLoader {
       path: String,
       canonicalOrientation: Boolean = false,
       minEdgePartitions: Int = 1,
-      partitionStrategy: PartitionStrategy = RandomVertexCut()):
+      partitionStrategy: PartitionStrategy = RandomVertexCut):
     Graph[Int, Int] = {
     // Parse the edge data table
     val edges = sc.textFile(path, minEdgePartitions).mapPartitions( iter =>
@@ -97,7 +97,7 @@ object GraphLoader {
         }
       })
     val defaultVertexAttr = 1
-    Graph(edges, defaultVertexAttr, partitionStrategy)
+    Graph.fromEdges(edges, defaultVertexAttr, partitionStrategy)
   } // end of edgeListFile
 
 }

--- a/graph/src/main/scala/org/apache/spark/graph/GraphLoader.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphLoader.scala
@@ -1,9 +1,6 @@
 package org.apache.spark.graph
 
-import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
-import org.apache.spark.graph.impl.GraphImpl
 
 
 object GraphLoader {

--- a/graph/src/main/scala/org/apache/spark/graph/GraphOps.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphOps.scala
@@ -35,14 +35,14 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
    * RDD.
    * @note Vertices with no in edges are not returned in the resulting RDD.
    */
-  lazy val inDegrees: VertexSetRDD[Int] = degreesRDD(EdgeDirection.In)
+  lazy val inDegrees: VertexRDD[Int] = degreesRDD(EdgeDirection.In)
 
 
   /**
    * Compute the out-degree of each vertex in the Graph returning an RDD.
    * @note Vertices with no out edges are not returned in the resulting RDD.
    */
-  lazy val outDegrees: VertexSetRDD[Int] = degreesRDD(EdgeDirection.Out)
+  lazy val outDegrees: VertexRDD[Int] = degreesRDD(EdgeDirection.Out)
 
 
   /**
@@ -50,7 +50,7 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
    * @note Vertices with no edges are not returned in the resulting
    * RDD.
    */
-  lazy val degrees: VertexSetRDD[Int] = degreesRDD(EdgeDirection.Both)
+  lazy val degrees: VertexRDD[Int] = degreesRDD(EdgeDirection.Both)
 
 
   /**
@@ -59,7 +59,7 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
    * @param edgeDirection the direction along which to collect
    * neighboring vertex attributes.
    */
-  private def degreesRDD(edgeDirection: EdgeDirection): VertexSetRDD[Int] = {
+  private def degreesRDD(edgeDirection: EdgeDirection): VertexRDD[Int] = {
     if (edgeDirection == EdgeDirection.In) {
       graph.mapReduceTriplets(et => Iterator((et.dstId,1)), _ + _)
     } else if (edgeDirection == EdgeDirection.Out) {
@@ -114,7 +114,7 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
       mapFunc: (Vid, EdgeTriplet[VD, ED]) => Option[A],
       reduceFunc: (A, A) => A,
       dir: EdgeDirection)
-    : VertexSetRDD[A] = {
+    : VertexRDD[A] = {
 
     ClosureCleaner.clean(mapFunc)
     ClosureCleaner.clean(reduceFunc)
@@ -154,7 +154,7 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
    * @return the vertex set of neighboring ids for each vertex.
    */
   def collectNeighborIds(edgeDirection: EdgeDirection) :
-    VertexSetRDD[Array[Vid]] = {
+    VertexRDD[Array[Vid]] = {
     val nbrs =
       if (edgeDirection == EdgeDirection.Both) {
         graph.mapReduceTriplets[Array[Vid]](
@@ -190,7 +190,7 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
    * vertex.
    */
   def collectNeighbors(edgeDirection: EdgeDirection) :
-    VertexSetRDD[ Array[(Vid, VD)] ] = {
+    VertexRDD[ Array[(Vid, VD)] ] = {
     val nbrs = graph.aggregateNeighbors[Array[(Vid,VD)]](
       (vid, edge) =>
         Some(Array( (edge.otherVertexId(vid), edge.otherVertexAttr(vid)) )),

--- a/graph/src/main/scala/org/apache/spark/graph/GraphOps.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphOps.scala
@@ -240,7 +240,6 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
         case None => data
       }
     }
-    ClosureCleaner.clean(uf)
     graph.outerJoinVertices(table)(uf)
   }
 

--- a/graph/src/main/scala/org/apache/spark/graph/PartitionStrategy.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/PartitionStrategy.scala
@@ -50,7 +50,7 @@ sealed trait PartitionStrategy extends Serializable {
  *
  *
  */
-case class EdgePartition2D() extends PartitionStrategy {
+case object EdgePartition2D extends PartitionStrategy {
   override def getPartition(src: Vid, dst: Vid, numParts: Pid): Pid = {
     val ceilSqrtNumParts: Pid = math.ceil(math.sqrt(numParts)).toInt
     val mixingPrime: Vid = 1125899906842597L
@@ -61,7 +61,7 @@ case class EdgePartition2D() extends PartitionStrategy {
 }
 
 
-case class EdgePartition1D() extends PartitionStrategy {
+case object EdgePartition1D extends PartitionStrategy {
   override def getPartition(src: Vid, dst: Vid, numParts: Pid): Pid = {
     val mixingPrime: Vid = 1125899906842597L
     (math.abs(src) * mixingPrime).toInt % numParts
@@ -73,7 +73,7 @@ case class EdgePartition1D() extends PartitionStrategy {
  * Assign edges to an aribtrary machine corresponding to a
  * random vertex cut.
  */
-case class RandomVertexCut() extends PartitionStrategy {
+case object RandomVertexCut extends PartitionStrategy {
   override def getPartition(src: Vid, dst: Vid, numParts: Pid): Pid = {
     math.abs((src, dst).hashCode()) % numParts
   }
@@ -85,7 +85,7 @@ case class RandomVertexCut() extends PartitionStrategy {
  * function ensures that edges of opposite direction between the same two vertices
  * will end up on the same partition.
  */
-case class CanonicalRandomVertexCut() extends PartitionStrategy {
+case object CanonicalRandomVertexCut extends PartitionStrategy {
   override def getPartition(src: Vid, dst: Vid, numParts: Pid): Pid = {
     val lower = math.min(src, dst)
     val higher = math.max(src, dst)

--- a/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
@@ -139,8 +139,6 @@ object Pregel {
    * @param initialMsg the message each vertex will receive at the on
    * the first iteration.
    *
-   * @param numIter the number of iterations to run this computation.
-   *
    * @param vprog the user-defined vertex program which runs on each
    * vertex and receives the inbound message and computes a new vertex
    * value.  On the first iteration the vertex program is invoked on

--- a/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
@@ -1,7 +1,5 @@
 package org.apache.spark.graph
 
-import org.apache.spark.rdd.RDD
-
 
 /**
  * This object implements a Pregel-like bulk-synchronous

--- a/graph/src/main/scala/org/apache/spark/graph/VertexSetRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexSetRDD.scala
@@ -277,10 +277,8 @@ class VertexSetRDD[@specialized VD: ClassManifest](
     // If the other set is a VertexSetRDD then we use the much more efficient leftZipJoin
     other match {
       case other: VertexSetRDD[VD2] =>
-        println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
         leftZipJoin(other)(f)
       case _ =>
-        println("------------------------------------------------------")
         new VertexSetRDD[VD3](
           partitionsRDD.zipPartitions(
             other.partitionBy(this.partitioner.get), preservesPartitioning = true)

--- a/graph/src/main/scala/org/apache/spark/graph/VertexSetRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexSetRDD.scala
@@ -184,27 +184,6 @@ class VertexSetRDD[@specialized VD: ClassManifest](
     this.mapVertexPartitions(_.map(f))
 
   /**
-   * Fill in missing values for all vertices in the index.
-   *
-   * @param missingValue the value to use for vertices that don't currently have values.
-   * @return A VertexSetRDD with a value for all vertices.
-   */
-  def fillMissing(missingValue: VD): VertexSetRDD[VD] = {
-    // TODO: I think this can be done using a join.
-    this.mapVertexPartitions { part =>
-      // Allocate a new values array with missing value as the default
-      val newValues = Array.fill(part.values.size)(missingValue)
-      // Copy over the old values
-      part.mask.iterator.foreach { ind =>
-        newValues(ind) = part.values(ind)
-      }
-      // Create a new mask with all vertices in the index
-      val newMask = part.index.getBitSet
-      new VertexPartition(part.index, newValues, newMask)
-    }
-  }
-
-  /**
    * Inner join this VertexSet with another VertexSet which has the
    * same Index.  This function will fail if both VertexSets do not
    * share the same index.  The resulting vertex set will only contain

--- a/graph/src/main/scala/org/apache/spark/graph/VertexSetRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexSetRDD.scala
@@ -101,6 +101,11 @@ class VertexSetRDD[@specialized VD: ClassManifest](
   /** Persist this RDD with the default storage level (`MEMORY_ONLY`). */
   override def cache(): VertexSetRDD[VD] = persist()
 
+  /** Return the number of vertices in this set. */
+  override def count(): Long = {
+    partitionsRDD.map(_.size).reduce(_ + _)
+  }
+
   /**
    * Provide the `RDD[(Vid, VD)]` equivalent output.
    */

--- a/graph/src/main/scala/org/apache/spark/graph/VertexSetRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexSetRDD.scala
@@ -276,7 +276,7 @@ class VertexSetRDD[@specialized VD: ClassManifest](
     // Test if the other vertex is a VertexSetRDD to choose the optimal join strategy.
     // If the other set is a VertexSetRDD then we use the much more efficient leftZipJoin
     other match {
-      case other: VertexSetRDD[VD2] =>
+      case other: VertexSetRDD[_] =>
         leftZipJoin(other)(f)
       case _ =>
         new VertexSetRDD[VD3](

--- a/graph/src/main/scala/org/apache/spark/graph/algorithms/ConnectedComponents.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/algorithms/ConnectedComponents.scala
@@ -5,19 +5,16 @@ import org.apache.spark.graph._
 
 object ConnectedComponents {
   /**
-   * Compute the connected component membership of each vertex and
-   * return an RDD with the vertex value containing the lowest vertex
-   * id in the connected component containing that vertex.
+   * Compute the connected component membership of each vertex and return an RDD with the vertex
+   * value containing the lowest vertex id in the connected component containing that vertex.
    *
-   * @tparam VD the vertex attribute type (discarded in the
-   * computation)
+   * @tparam VD the vertex attribute type (discarded in the computation)
    * @tparam ED the edge attribute type (preserved in the computation)
    *
-   * @param graph the graph for which to compute the connected
-   * components
+   * @param graph the graph for which to compute the connected components
    *
-   * @return a graph with vertex attributes containing the smallest
-   * vertex in each connected component
+   * @return a graph with vertex attributes containing the smallest vertex in each
+   *         connected component
    */
   def run[VD: Manifest, ED: Manifest](graph: Graph[VD, ED]): Graph[Vid, ED] = {
     val ccGraph = graph.mapVertices { case (vid, _) => vid }

--- a/graph/src/main/scala/org/apache/spark/graph/algorithms/ConnectedComponents.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/algorithms/ConnectedComponents.scala
@@ -1,0 +1,40 @@
+package org.apache.spark.graph.algorithms
+
+import org.apache.spark.graph._
+
+
+object ConnectedComponents {
+  /**
+   * Compute the connected component membership of each vertex and
+   * return an RDD with the vertex value containing the lowest vertex
+   * id in the connected component containing that vertex.
+   *
+   * @tparam VD the vertex attribute type (discarded in the
+   * computation)
+   * @tparam ED the edge attribute type (preserved in the computation)
+   *
+   * @param graph the graph for which to compute the connected
+   * components
+   *
+   * @return a graph with vertex attributes containing the smallest
+   * vertex in each connected component
+   */
+  def run[VD: Manifest, ED: Manifest](graph: Graph[VD, ED]): Graph[Vid, ED] = {
+    val ccGraph = graph.mapVertices { case (vid, _) => vid }
+
+    def sendMessage(edge: EdgeTriplet[Vid, ED]) = {
+      if (edge.srcAttr < edge.dstAttr) {
+        Iterator((edge.dstId, edge.srcAttr))
+      } else if (edge.srcAttr > edge.dstAttr) {
+        Iterator((edge.srcId, edge.dstAttr))
+      } else {
+        Iterator.empty
+      }
+    }
+    val initialMessage = Long.MaxValue
+    Pregel(ccGraph, initialMessage)(
+      vprog = (id, attr, msg) => math.min(attr, msg),
+      sendMsg = sendMessage,
+      mergeMsg = (a, b) => math.min(a, b))
+  } // end of connectedComponents
+}

--- a/graph/src/main/scala/org/apache/spark/graph/algorithms/PageRank.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/algorithms/PageRank.scala
@@ -1,0 +1,154 @@
+package org.apache.spark.graph.algorithms
+
+import org.apache.spark.graph._
+
+
+object PageRank {
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph
+   * with vertex attributes containing the PageRank and edge
+   * attributes the normalized edge weight.
+   *
+   * The following PageRank fixed point is computed for each vertex.
+   *
+   * {{{
+   * var PR = Array.fill(n)( 1.0 )
+   * val oldPR = Array.fill(n)( 1.0 )
+   * for( iter <- 0 until numIter ) {
+   *   swap(oldPR, PR)
+   *   for( i <- 0 until n ) {
+   *     PR[i] = alpha + (1 - alpha) * inNbrs[i].map(j => oldPR[j] / outDeg[j]).sum
+   *   }
+   * }
+   * }}}
+   *
+   * where `alpha` is the random reset probability (typically 0.15),
+   * `inNbrs[i]` is the set of neighbors whick link to `i` and
+   * `outDeg[j]` is the out degree of vertex `j`.
+   *
+   * Note that this is not the "normalized" PageRank and as a consequence pages that have no
+   * inlinks will have a PageRank of alpha.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param numIter the number of iterations of PageRank to run
+   * @param resetProb the random reset probability (alpha)
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   *
+   */
+  def run[VD: Manifest, ED: Manifest](
+      graph: Graph[VD, ED], numIter: Int, resetProb: Double = 0.15): Graph[Double, Double] =
+  {
+
+    /**
+     * Initialize the pagerankGraph with each edge attribute having
+     * weight 1/outDegree and each vertex with attribute 1.0.
+     */
+    val pagerankGraph: Graph[Double, Double] = graph
+      // Associate the degree with each vertex
+      .outerJoinVertices(graph.outDegrees){
+      (vid, vdata, deg) => deg.getOrElse(0)
+    }
+      // Set the weight on the edges based on the degree
+      .mapTriplets( e => 1.0 / e.srcAttr )
+      // Set the vertex attributes to the initial pagerank values
+      .mapVertices( (id, attr) => 1.0 )
+
+    // Display statistics about pagerank
+    println(pagerankGraph.statistics)
+
+    // Define the three functions needed to implement PageRank in the GraphX
+    // version of Pregel
+    def vertexProgram(id: Vid, attr: Double, msgSum: Double): Double =
+      resetProb + (1.0 - resetProb) * msgSum
+    def sendMessage(edge: EdgeTriplet[Double, Double]) =
+      Iterator((edge.dstId, edge.srcAttr * edge.attr))
+    def messageCombiner(a: Double, b: Double): Double = a + b
+    // The initial message received by all vertices in PageRank
+    val initialMessage = 0.0
+
+    // Execute pregel for a fixed number of iterations.
+    Pregel(pagerankGraph, initialMessage, numIter)(
+      vertexProgram, sendMessage, messageCombiner)
+  }
+
+  /**
+   * Run a dynamic version of PageRank returning a graph with vertex attributes containing the
+   * PageRank and edge attributes containing the normalized edge weight.
+   *
+   * {{{
+   * var PR = Array.fill(n)( 1.0 )
+   * val oldPR = Array.fill(n)( 0.0 )
+   * while( max(abs(PR - oldPr)) > tol ) {
+   *   swap(oldPR, PR)
+   *   for( i <- 0 until n if abs(PR[i] - oldPR[i]) > tol ) {
+   *     PR[i] = alpha + (1 - \alpha) * inNbrs[i].map(j => oldPR[j] / outDeg[j]).sum
+   *   }
+   * }
+   * }}}
+   *
+   * where `alpha` is the random reset probability (typically 0.15), `inNbrs[i]` is the set of
+   * neighbors whick link to `i` and `outDeg[j]` is the out degree of vertex `j`.
+   *
+   * Note that this is not the "normalized" PageRank and as a consequence pages that have no
+   * inlinks will have a PageRank of alpha.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param tol the tolerance allowed at convergence (smaller => more * accurate).
+   * @param resetProb the random reset probability (alpha)
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   */
+  def runUntillConvergence[VD: Manifest, ED: Manifest](
+      graph: Graph[VD, ED], tol: Double, resetProb: Double = 0.15): Graph[Double, Double] =
+  {
+    // Initialize the pagerankGraph with each edge attribute
+    // having weight 1/outDegree and each vertex with attribute 1.0.
+    val pagerankGraph: Graph[(Double, Double), Double] = graph
+      // Associate the degree with each vertex
+      .outerJoinVertices(graph.outDegrees) {
+        (vid, vdata, deg) => deg.getOrElse(0)
+      }
+      // Set the weight on the edges based on the degree
+      .mapTriplets( e => 1.0 / e.srcAttr )
+      // Set the vertex attributes to (initalPR, delta = 0)
+      .mapVertices( (id, attr) => (0.0, 0.0) )
+
+    // Display statistics about pagerank
+    println(pagerankGraph.statistics)
+
+    // Define the three functions needed to implement PageRank in the GraphX
+    // version of Pregel
+    def vertexProgram(id: Vid, attr: (Double, Double), msgSum: Double): (Double, Double) = {
+      val (oldPR, lastDelta) = attr
+      val newPR = oldPR + (1.0 - resetProb) * msgSum
+      (newPR, newPR - oldPR)
+    }
+
+    def sendMessage(edge: EdgeTriplet[(Double, Double), Double]) = {
+      if (edge.srcAttr._2 > tol) {
+        Iterator((edge.dstId, edge.srcAttr._2 * edge.attr))
+      } else {
+        Iterator.empty
+      }
+    }
+
+    def messageCombiner(a: Double, b: Double): Double = a + b
+
+    // The initial message received by all vertices in PageRank
+    val initialMessage = resetProb / (1.0 - resetProb)
+
+    // Execute a dynamic version of Pregel.
+    Pregel(pagerankGraph, initialMessage)(vertexProgram, sendMessage, messageCombiner)
+      .mapVertices((vid, attr) => attr._1)
+  } // end of deltaPageRank
+}

--- a/graph/src/main/scala/org/apache/spark/graph/algorithms/TriangleCount.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/algorithms/TriangleCount.scala
@@ -1,0 +1,74 @@
+package org.apache.spark.graph.algorithms
+
+import org.apache.spark.graph._
+
+
+object TriangleCount {
+  /**
+   * Compute the number of triangles passing through each vertex.
+   *
+   * The algorithm is relatively straightforward and can be computed in three steps:
+   *
+   * 1) Compute the set of neighbors for each vertex
+   * 2) For each edge compute the intersection of the sets and send the
+   *    count to both vertices.
+   * 3) Compute the sum at each vertex and divide by two since each
+   *    triangle is counted twice.
+   *
+   *
+   * @param graph a graph with `sourceId` less than `destId`
+   * @return
+   */
+  def run[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD,ED]): Graph[Int, ED] = {
+    // Remove redundant edges
+    val g = graph.groupEdges((a, b) => a).cache
+
+    // Construct set representations of the neighborhoods
+    val nbrSets: VertexRDD[VertexSet] =
+      g.collectNeighborIds(EdgeDirection.Both).mapValues { (vid, nbrs) =>
+        val set = new VertexSet(4)
+        var i = 0
+        while (i < nbrs.size) {
+          // prevent self cycle
+          if(nbrs(i) != vid) {
+            set.add(nbrs(i))
+          }
+          i += 1
+        }
+        set
+      }
+    // join the sets with the graph
+    val setGraph: Graph[VertexSet, ED] = g.outerJoinVertices(nbrSets) {
+      (vid, _, optSet) => optSet.getOrElse(null)
+    }
+    // Edge function computes intersection of smaller vertex with larger vertex
+    def edgeFunc(et: EdgeTriplet[VertexSet, ED]): Iterator[(Vid, Int)] = {
+      assert(et.srcAttr != null)
+      assert(et.dstAttr != null)
+      val (smallSet, largeSet) = if (et.srcAttr.size < et.dstAttr.size) {
+        (et.srcAttr, et.dstAttr)
+      } else {
+        (et.dstAttr, et.srcAttr)
+      }
+      val iter = smallSet.iterator
+      var counter: Int = 0
+      while (iter.hasNext) {
+        val vid = iter.next
+        if (vid != et.srcId && vid != et.dstId && largeSet.contains(vid)) { counter += 1 }
+      }
+      Iterator((et.srcId, counter), (et.dstId, counter))
+    }
+    // compute the intersection along edges
+    val counters: VertexRDD[Int] = setGraph.mapReduceTriplets(edgeFunc, _ + _)
+    // Merge counters with the graph and divide by two since each triangle is counted twice
+    g.outerJoinVertices(counters) {
+      (vid, _, optCounter: Option[Int]) =>
+        val dblCount = optCounter.getOrElse(0)
+        // double count should be even (divisible by two)
+        assert((dblCount & 1) == 0)
+        dblCount / 2
+    }
+
+  } // end of TriangleCount
+
+}

--- a/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartitionBuilder.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartitionBuilder.scala
@@ -1,27 +1,24 @@
 package org.apache.spark.graph.impl
 
-import scala.collection.mutable.ArrayBuilder
 import org.apache.spark.graph._
+import org.apache.spark.util.collection.PrimitiveVector
 
 
 //private[graph]
-class EdgePartitionBuilder[@specialized(Char, Int, Boolean, Byte, Long, Float, Double)
-ED: ClassManifest]{
-  val srcIds = new VertexArrayList
-  val dstIds = new VertexArrayList
-  var dataBuilder = ArrayBuilder.make[ED]
+class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassManifest] {
 
+  val srcIds = new PrimitiveVector[Vid]
+  val dstIds = new PrimitiveVector[Vid]
+  var dataBuilder = new PrimitiveVector[ED]
 
   /** Add a new edge to the partition. */
   def add(src: Vid, dst: Vid, d: ED) {
-    srcIds.add(src)
-    dstIds.add(dst)
+    srcIds += src
+    dstIds += dst
     dataBuilder += d
   }
 
   def toEdgePartition: EdgePartition[ED] = {
-    new EdgePartition(srcIds.toLongArray(), dstIds.toLongArray(), dataBuilder.result())
+    new EdgePartition(srcIds.trim().array, dstIds.trim().array, dataBuilder.trim().array)
   }
-
-
 }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/EdgeTripletIterator.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/EdgeTripletIterator.scala
@@ -1,0 +1,60 @@
+package org.apache.spark.graph.impl
+
+import scala.collection.mutable
+
+import org.apache.spark.graph._
+import org.apache.spark.util.collection.PrimitiveKeyOpenHashMap
+
+
+/**
+ * The Iterator type returned when constructing edge triplets. This class technically could be
+ * an anonymous class in GraphImpl.triplets, but we name it here explicitly so it is easier to
+ * debug / profile.
+ */
+private[impl]
+class EdgeTripletIterator[VD: ClassManifest, ED: ClassManifest](
+    val vidToIndex: VertexIdToIndexMap,
+    val vertexArray: Array[VD],
+    val edgePartition: EdgePartition[ED])
+  extends Iterator[EdgeTriplet[VD, ED]] {
+
+  // Current position in the array.
+  private var pos = 0
+
+  // A triplet object that this iterator.next() call returns. We reuse this object to avoid
+  // allocating too many temporary Java objects.
+  private val triplet = new EdgeTriplet[VD, ED]
+
+  private val vmap = new PrimitiveKeyOpenHashMap[Vid, VD](vidToIndex, vertexArray)
+
+  override def hasNext: Boolean = pos < edgePartition.size
+
+  override def next() = {
+    triplet.srcId = edgePartition.srcIds(pos)
+    // assert(vmap.containsKey(e.src.id))
+    triplet.srcAttr = vmap(triplet.srcId)
+    triplet.dstId = edgePartition.dstIds(pos)
+    // assert(vmap.containsKey(e.dst.id))
+    triplet.dstAttr = vmap(triplet.dstId)
+    triplet.attr = edgePartition.data(pos)
+    pos += 1
+    triplet
+  }
+
+  // TODO: Why do we need this?
+  override def toList: List[EdgeTriplet[VD, ED]] = {
+    val lb = new mutable.ListBuffer[EdgeTriplet[VD,ED]]
+    val currentEdge = new EdgeTriplet[VD, ED]
+    for (i <- 0 until edgePartition.size) {
+      currentEdge.srcId = edgePartition.srcIds(i)
+      // assert(vmap.containsKey(e.src.id))
+      currentEdge.srcAttr = vmap(currentEdge.srcId)
+      currentEdge.dstId = edgePartition.dstIds(i)
+      // assert(vmap.containsKey(e.dst.id))
+      currentEdge.dstAttr = vmap(currentEdge.dstId)
+      currentEdge.attr = edgePartition.data(i)
+      lb += currentEdge
+    }
+    lb.toList
+  }
+}

--- a/graph/src/main/scala/org/apache/spark/graph/impl/EdgeTripletIterator.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/EdgeTripletIterator.scala
@@ -1,7 +1,5 @@
 package org.apache.spark.graph.impl
 
-import scala.collection.mutable
-
 import org.apache.spark.graph._
 import org.apache.spark.util.collection.PrimitiveKeyOpenHashMap
 
@@ -39,22 +37,5 @@ class EdgeTripletIterator[VD: ClassManifest, ED: ClassManifest](
     triplet.attr = edgePartition.data(pos)
     pos += 1
     triplet
-  }
-
-  // TODO: Why do we need this?
-  override def toList: List[EdgeTriplet[VD, ED]] = {
-    val lb = new mutable.ListBuffer[EdgeTriplet[VD,ED]]
-    val currentEdge = new EdgeTriplet[VD, ED]
-    for (i <- 0 until edgePartition.size) {
-      currentEdge.srcId = edgePartition.srcIds(i)
-      // assert(vmap.containsKey(e.src.id))
-      currentEdge.srcAttr = vmap(currentEdge.srcId)
-      currentEdge.dstId = edgePartition.dstIds(i)
-      // assert(vmap.containsKey(e.dst.id))
-      currentEdge.dstAttr = vmap(currentEdge.dstId)
-      currentEdge.attr = edgePartition.data(i)
-      lb += currentEdge
-    }
-    lb.toList
   }
 }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -258,9 +258,6 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       }
     }
 
-    // Permit joining the result of mapReduceTriplets back with vTable
-    vTable.cache()
-
     // do the final reduction reusing the index map
     vTable.aggregateUsingIndex(preAgg, reduceFunc)
   } // end of mapReduceTriplets

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -258,6 +258,9 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       }
     }
 
+    // Permit joining the result of mapReduceTriplets back with vTable
+    vTable.cache()
+
     // do the final reduction reusing the index map
     vTable.aggregateUsingIndex(preAgg, reduceFunc)
   } // end of mapReduceTriplets

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -268,7 +268,6 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
   override def outerJoinVertices[U: ClassManifest, VD2: ClassManifest]
     (updates: RDD[(Vid, U)])(updateF: (Vid, VD, Option[U]) => VD2): Graph[VD2, ED] = {
     ClosureCleaner.clean(updateF)
-    println("type of --------------------------- " + updates)
     val newVTable = vTable.leftJoin(updates)(updateF)
     new GraphImpl(newVTable, eTable, vertexPlacement, partitioner)
   }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -256,10 +256,10 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       msgBS.iterator.map { ind =>
         new AggregationMsg[A](vidToIndex.getValue(ind), msgArray(ind))
       }
-    }.partitionBy(vTable.partitioner.get)
+    }
 
     // do the final reduction reusing the index map
-    VertexSetRDD.aggregate(preAgg, vTable.index, reduceFunc)
+    vTable.aggregateUsingIndex(preAgg, reduceFunc)
   } // end of mapReduceTriplets
 
   override def outerJoinVertices[U: ClassManifest, VD2: ClassManifest]

--- a/graph/src/main/scala/org/apache/spark/graph/impl/Serializers.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/Serializers.scala
@@ -101,9 +101,9 @@ class IntAggMsgSerializer extends Serializer {
 
     override def serializeStream(s: OutputStream) = new ShuffleSerializationStream(s) {
       def writeObject[T](t: T) = {
-        val msg = t.asInstanceOf[AggregationMsg[Int]]
-        writeLong(msg.vid)
-        writeUnsignedVarInt(msg.data)
+        val msg = t.asInstanceOf[(Vid, Int)]
+        writeLong(msg._1)
+        writeUnsignedVarInt(msg._2)
         this
       }
     }
@@ -112,7 +112,7 @@ class IntAggMsgSerializer extends Serializer {
       override def readObject[T](): T = {
         val a = readLong()
         val b = readUnsignedVarInt()
-        new AggregationMsg[Int](a, b).asInstanceOf[T]
+        (a, b).asInstanceOf[T]
       }
     }
   }
@@ -124,9 +124,9 @@ class LongAggMsgSerializer extends Serializer {
 
     override def serializeStream(s: OutputStream) = new ShuffleSerializationStream(s) {
       def writeObject[T](t: T) = {
-        val msg = t.asInstanceOf[AggregationMsg[Long]]
-        writeVarLong(msg.vid, optimizePositive = false)
-        writeVarLong(msg.data, optimizePositive = true)
+        val msg = t.asInstanceOf[(Vid, Long)]
+        writeVarLong(msg._1, optimizePositive = false)
+        writeVarLong(msg._2, optimizePositive = true)
         this
       }
     }
@@ -135,7 +135,7 @@ class LongAggMsgSerializer extends Serializer {
       override def readObject[T](): T = {
         val a = readVarLong(optimizePositive = false)
         val b = readVarLong(optimizePositive = true)
-        new AggregationMsg[Long](a, b).asInstanceOf[T]
+        (a, b).asInstanceOf[T]
       }
     }
   }
@@ -148,9 +148,9 @@ class DoubleAggMsgSerializer extends Serializer {
 
     override def serializeStream(s: OutputStream) = new ShuffleSerializationStream(s) {
       def writeObject[T](t: T) = {
-        val msg = t.asInstanceOf[AggregationMsg[Double]]
-        writeVarLong(msg.vid, optimizePositive = false)
-        writeDouble(msg.data)
+        val msg = t.asInstanceOf[(Vid, Double)]
+        writeVarLong(msg._1, optimizePositive = false)
+        writeDouble(msg._2)
         this
       }
     }
@@ -159,7 +159,7 @@ class DoubleAggMsgSerializer extends Serializer {
       def readObject[T](): T = {
         val a = readVarLong(optimizePositive = false)
         val b = readDouble()
-        new AggregationMsg[Double](a, b).asInstanceOf[T]
+        (a, b).asInstanceOf[T]
       }
     }
   }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -5,61 +5,60 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.util.collection.{OpenHashSet, PrimitiveKeyOpenHashMap}
 
 import org.apache.spark.graph._
-import org.apache.spark.graph.impl.MsgRDDFunctions._
 
 /**
  * Stores the vertex attribute values after they are replicated.
  */
+private[impl]
 class VTableReplicated[VD: ClassManifest](
     vTable: VertexSetRDD[VD],
     eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
     vertexPlacement: VertexPlacement) {
 
   val bothAttrs: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    VTableReplicated.createVTableReplicated(vTable, eTable, vertexPlacement, true, true)
+    createVTableReplicated(vTable, eTable, vertexPlacement, true, true)
+
   val srcAttrOnly: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    VTableReplicated.createVTableReplicated(vTable, eTable, vertexPlacement, true, false)
+    createVTableReplicated(vTable, eTable, vertexPlacement, true, false)
+
   val dstAttrOnly: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    VTableReplicated.createVTableReplicated(vTable, eTable, vertexPlacement, false, true)
+    createVTableReplicated(vTable, eTable, vertexPlacement, false, true)
+
   val noAttrs: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    VTableReplicated.createVTableReplicated(vTable, eTable, vertexPlacement, false, false)
+    createVTableReplicated(vTable, eTable, vertexPlacement, false, false)
 
-
-  def get(includeSrcAttr: Boolean, includeDstAttr: Boolean)
-    : RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
-    (includeSrcAttr, includeDstAttr) match {
+  def get(includeSrc: Boolean, includeDst: Boolean): RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] = {
+    (includeSrc, includeDst) match {
       case (true, true) => bothAttrs
       case (true, false) => srcAttrOnly
       case (false, true) => dstAttrOnly
       case (false, false) => noAttrs
     }
-}
+  }
 
-class VertexAttributeBlock[VD: ClassManifest](val vids: Array[Vid], val attrs: Array[VD])
+  private def createVTableReplicated[VD: ClassManifest](
+       vTable: VertexSetRDD[VD],
+       eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
+       vertexPlacement: VertexPlacement,
+       includeSrcAttr: Boolean,
+       includeDstAttr: Boolean): RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] = {
 
-object VTableReplicated {
-  protected def createVTableReplicated[VD: ClassManifest](
-      vTable: VertexSetRDD[VD],
-      eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
-      vertexPlacement: VertexPlacement,
-      includeSrcAttr: Boolean,
-      includeDstAttr: Boolean): RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] = {
     val placement = vertexPlacement.get(includeSrcAttr, includeDstAttr)
 
     // Send each edge partition the vertex attributes it wants, as specified in
     // vertexPlacement
     val msgsByPartition = placement.zipPartitions(vTable.partitionsRDD) {
       (pid2vidIter, vertexPartIter) =>
-      val pid2vid = pid2vidIter.next()
-      val vertexPart = vertexPartIter.next()
+        val pid2vid = pid2vidIter.next()
+        val vertexPart = vertexPartIter.next()
 
-      val vmap = new PrimitiveKeyOpenHashMap(vertexPart.index, vertexPart.values)
-      val output = new Array[(Pid, VertexAttributeBlock[VD])](pid2vid.size)
-      for (pid <- 0 until pid2vid.size) {
-        val block = new VertexAttributeBlock(pid2vid(pid), pid2vid(pid).map(vid => vmap(vid)))
-        output(pid) = (pid, block)
-      }
-      output.iterator
+        val vmap = new PrimitiveKeyOpenHashMap(vertexPart.index, vertexPart.values)
+        val output = new Array[(Pid, VertexAttributeBlock[VD])](pid2vid.size)
+        for (pid <- 0 until pid2vid.size) {
+          val block = new VertexAttributeBlock(pid2vid(pid), pid2vid(pid).map(vid => vmap(vid)))
+          output(pid) = (pid, block)
+        }
+        output.iterator
     }.partitionBy(eTable.partitioner.get).cache()
 
     // Within each edge partition, create a local map from vid to an index into
@@ -81,20 +80,22 @@ object VTableReplicated {
     // msgsByPartition into the correct locations specified in localVidMap
     localVidMap.zipPartitions(msgsByPartition) {
       (mapIter, msgsIter) =>
-      val (pid, vidToIndex) = mapIter.next()
-      assert(!mapIter.hasNext)
-      // Populate the vertex array using the vidToIndex map
-      val vertexArray = new Array[VD](vidToIndex.capacity)
-      for ((_, block) <- msgsIter) {
-        for (i <- 0 until block.vids.size) {
-          val vid = block.vids(i)
-          val attr = block.attrs(i)
-          val ind = vidToIndex.getPos(vid) & OpenHashSet.POSITION_MASK
-          vertexArray(ind) = attr
+        val (pid, vidToIndex) = mapIter.next()
+        assert(!mapIter.hasNext)
+        // Populate the vertex array using the vidToIndex map
+        val vertexArray = new Array[VD](vidToIndex.capacity)
+        for ((_, block) <- msgsIter) {
+          for (i <- 0 until block.vids.size) {
+            val vid = block.vids(i)
+            val attr = block.attrs(i)
+            val ind = vidToIndex.getPos(vid) & OpenHashSet.POSITION_MASK
+            vertexArray(ind) = attr
+          }
         }
-      }
-      Iterator((pid, (vidToIndex, vertexArray)))
+        Iterator((pid, (vidToIndex, vertexArray)))
     }.cache()
   }
 
 }
+
+class VertexAttributeBlock[VD: ClassManifest](val vids: Array[Vid], val attrs: Array[VD])

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -2,7 +2,7 @@ package org.apache.spark.graph.impl
 
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.util.collection.{OpenHashSet, PrimitiveKeyOpenHashMap}
+import org.apache.spark.util.collection.OpenHashSet
 
 import org.apache.spark.graph._
 

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -11,8 +11,8 @@ import org.apache.spark.graph._
  */
 private[impl]
 class VTableReplicated[VD: ClassManifest](
-    vTable: VertexSetRDD[VD],
-    eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
+    vTable: VertexRDD[VD],
+    eTable: EdgeRDD[_],
     vertexPlacement: VertexPlacement) {
 
   val bothAttrs: RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] =
@@ -37,8 +37,8 @@ class VTableReplicated[VD: ClassManifest](
   }
 
   private def createVTableReplicated[VD: ClassManifest](
-       vTable: VertexSetRDD[VD],
-       eTable: RDD[(Pid, EdgePartition[ED])] forSome { type ED },
+       vTable: VertexRDD[VD],
+       eTable: EdgeRDD[_],
        vertexPlacement: VertexPlacement,
        includeSrcAttr: Boolean,
        includeDstAttr: Boolean): RDD[(Pid, (VertexIdToIndexMap, Array[VD]))] = {
@@ -66,7 +66,7 @@ class VTableReplicated[VD: ClassManifest](
     // will receive, because it stores vids from both the source and destination
     // of edges. It must always include both source and destination vids because
     // some operations, such as GraphImpl.mapReduceTriplets, rely on this.
-    val localVidMap = eTable.mapPartitions(_.map {
+    val localVidMap = eTable.partitionsRDD.mapPartitions(_.map {
       case (pid, epart) =>
         val vidToIndex = new VertexIdToIndexMap
         epart.foreach { e =>

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
@@ -68,7 +68,7 @@ class VertexPartition[@specialized(Char, Int, Boolean, Byte, Long, Float, Double
     for ((k, v) <- this.iterator) {
       hashMap.setMerge(k, v, arbitraryMerge)
     }
-    new VertexPartition(hashMap.keySet, hashMap._values, index.getBitSet)
+    new VertexPartition(hashMap.keySet, hashMap._values, hashMap.keySet.getBitSet)
   }
 
   def iterator = mask.iterator.map(ind => (index.getValueSafe(ind), values(ind)))

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
@@ -35,11 +35,6 @@ class VertexPartition[@specialized(Long, Int, Double) VD: ClassManifest](
     private val mask: BitSet)
   extends Logging {
 
-  // TODO: Encapsulate the internal data structures in this class so callers don't need to
-  // understand the internal data structures. This can possibly be achieved by implementing
-  // the aggregate and join functions in this class, and VertexSetRDD can simply call into
-  // that.
-
   val capacity: Int = index.capacity
 
   def size: Int = mask.cardinality()

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
@@ -30,9 +30,9 @@ private[graph] object VertexPartition {
 
 private[graph]
 class VertexPartition[@specialized(Long, Int, Double) VD: ClassManifest](
-    val index: VertexIdToIndexMap,
-    val values: Array[VD],
-    val mask: BitSet)
+    private val index: VertexIdToIndexMap,
+    private val values: Array[VD],
+    private val mask: BitSet)
   extends Logging {
 
   // TODO: Encapsulate the internal data structures in this class so callers don't need to
@@ -42,7 +42,10 @@ class VertexPartition[@specialized(Long, Int, Double) VD: ClassManifest](
 
   val capacity: Int = index.capacity
 
-  def size: Int = mask.cardinality
+  def size: Int = mask.cardinality()
+
+  /** Return the vertex attribute for the given vertex ID. */
+  def apply(vid: Vid): VD = values(index.getPos(vid))
 
   /**
    * Pass each vertex attribute along with the vertex id through a map

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
@@ -42,6 +42,8 @@ class VertexPartition[@specialized(Long, Int, Double) VD: ClassManifest](
 
   val capacity: Int = index.capacity
 
+  def size: Int = mask.cardinality
+
   /**
    * Pass each vertex attribute along with the vertex id through a map
    * function and retain the original RDD's partitioning and index.

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPlacement.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPlacement.scala
@@ -1,10 +1,9 @@
 package org.apache.spark.graph.impl
 
 import org.apache.spark.SparkContext._
+import org.apache.spark.graph._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
-
-import org.apache.spark.graph._
 import org.apache.spark.util.collection.PrimitiveVector
 
 /**
@@ -41,7 +40,7 @@ class VertexPlacement(eTable: EdgeRDD[_], vTable: VertexRDD[_]) {
       val numEdges = edgePartition.size
       val vSet = new VertexSet
       if (includeSrcAttr) {  // Add src vertices to the set.
-      var i = 0
+        var i = 0
         while (i < numEdges) {
           vSet.add(edgePartition.srcIds(i))
           i += 1

--- a/graph/src/main/scala/org/apache/spark/graph/package.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/package.scala
@@ -6,10 +6,11 @@ import org.apache.spark.util.collection.OpenHashSet
 package object graph {
 
   type Vid = Long
+
+  // TODO: Consider using Char.
   type Pid = Int
 
   type VertexSet = OpenHashSet[Vid]
-  type VertexArrayList = it.unimi.dsi.fastutil.longs.LongArrayList
 
   //  type VertexIdToIndexMap = it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap
   type VertexIdToIndexMap = OpenHashSet[Vid]
@@ -18,11 +19,4 @@ package object graph {
    * Return the default null-like value for a data type T.
    */
   def nullValue[T] = null.asInstanceOf[T]
-
-
-  private[graph]
-  case class MutableTuple2[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) U,
-                           @specialized(Char, Int, Boolean, Byte, Long, Float, Double) V](
-    var _1: U, var _2: V)
-
 }

--- a/graph/src/main/scala/org/apache/spark/graph/util/GraphGenerators.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/util/GraphGenerators.scala
@@ -268,14 +268,14 @@ object GraphGenerators {
    * Create a star graph with vertex 0 being the center.
    *
    * @param sc the spark context in which to construct the graph
-   * @param the number of vertices in the star
+   * @param nverts the number of vertices in the star
    *
    * @return A star graph containing `nverts` vertices with vertex 0
    * being the center vertex.
    */
   def starGraph(sc: SparkContext, nverts: Int): Graph[Int, Int] = {
     val edges: RDD[(Vid, Vid)] = sc.parallelize(1 until nverts).map(vid => (vid, 0))
-    Graph(edges, 1)
+    Graph.fromEdgeTuples(edges, 1)
   } // end of starGraph
 
 

--- a/graph/src/test/resources/log4j.properties
+++ b/graph/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file core/target/unit-tests.log
+log4j.rootCategory=INFO, file
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=false
+log4j.appender.file.file=graph/target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %p %c{1}: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.eclipse.jetty=WARN
+org.eclipse.jetty.LEVEL=WARN

--- a/graph/src/test/scala/org/apache/spark/graph/AnalyticsSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/AnalyticsSuite.scala
@@ -54,7 +54,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
   test("Star PageRank") {
     withSpark(new SparkContext("local", "test")) { sc =>
       val nVertices = 100
-      val starGraph = GraphGenerators.starGraph(sc, nVertices)
+      val starGraph = GraphGenerators.starGraph(sc, nVertices).cache()
       val resetProb = 0.15
       val prGraph1 = Analytics.pagerank(starGraph, 1, resetProb)
       val prGraph2 = Analytics.pagerank(starGraph, 2, resetProb)
@@ -86,7 +86,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
 
   test("Grid PageRank") {
     withSpark(new SparkContext("local", "test")) { sc =>
-      val gridGraph = GraphGenerators.gridGraph(sc, 10, 10)
+      val gridGraph = GraphGenerators.gridGraph(sc, 10, 10).cache()
       val resetProb = 0.15
       val prGraph1 = Analytics.pagerank(gridGraph, 50, resetProb).cache()
       val prGraph2 = Analytics.deltaPagerank(gridGraph, 0.0001, resetProb).cache()
@@ -109,7 +109,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
 
   test("Grid Connected Components") {
     withSpark(new SparkContext("local", "test")) { sc =>
-      val gridGraph = GraphGenerators.gridGraph(sc, 10, 10)
+      val gridGraph = GraphGenerators.gridGraph(sc, 10, 10).cache()
       val ccGraph = Analytics.connectedComponents(gridGraph).cache()
       val maxCCid = ccGraph.vertices.map { case (vid, ccId) => ccId }.sum
       assert(maxCCid === 0)
@@ -119,7 +119,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
 
   test("Reverse Grid Connected Components") {
     withSpark(new SparkContext("local", "test")) { sc =>
-      val gridGraph = GraphGenerators.gridGraph(sc, 10, 10).reverse
+      val gridGraph = GraphGenerators.gridGraph(sc, 10, 10).reverse.cache()
       val ccGraph = Analytics.connectedComponents(gridGraph).cache()
       val maxCCid = ccGraph.vertices.map { case (vid, ccId) => ccId }.sum
       assert(maxCCid === 0)
@@ -132,7 +132,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
       val chain1 = (0 until 9).map(x => (x, x+1) )
       val chain2 = (10 until 20).map(x => (x, x+1) )
       val rawEdges = sc.parallelize(chain1 ++ chain2, 3).map { case (s,d) => (s.toLong, d.toLong) }
-      val twoChains = Graph.fromEdgeTuples(rawEdges, 1.0)
+      val twoChains = Graph.fromEdgeTuples(rawEdges, 1.0).cache()
       val ccGraph = Analytics.connectedComponents(twoChains).cache()
       val vertices = ccGraph.vertices.collect()
       for ( (id, cc) <- vertices ) {
@@ -156,7 +156,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
       val chain1 = (0 until 9).map(x => (x, x+1) )
       val chain2 = (10 until 20).map(x => (x, x+1) )
       val rawEdges = sc.parallelize(chain1 ++ chain2, 3).map { case (s,d) => (s.toLong, d.toLong) }
-      val twoChains = Graph.fromEdgeTuples(rawEdges, true).reverse
+      val twoChains = Graph.fromEdgeTuples(rawEdges, true).reverse.cache()
       val ccGraph = Analytics.connectedComponents(twoChains).cache()
       val vertices = ccGraph.vertices.collect
       for ( (id, cc) <- vertices ) {

--- a/graph/src/test/scala/org/apache/spark/graph/AnalyticsSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/AnalyticsSuite.scala
@@ -132,9 +132,9 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
       val chain1 = (0 until 9).map(x => (x, x+1) )
       val chain2 = (10 until 20).map(x => (x, x+1) )
       val rawEdges = sc.parallelize(chain1 ++ chain2, 3).map { case (s,d) => (s.toLong, d.toLong) }
-      val twoChains = Graph(rawEdges, 1.0)
+      val twoChains = Graph.fromEdgeTuples(rawEdges, 1.0)
       val ccGraph = Analytics.connectedComponents(twoChains).cache()
-      val vertices = ccGraph.vertices.collect
+      val vertices = ccGraph.vertices.collect()
       for ( (id, cc) <- vertices ) {
         if(id < 10) { assert(cc === 0) }
         else { assert(cc === 10) }
@@ -156,7 +156,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
       val chain1 = (0 until 9).map(x => (x, x+1) )
       val chain2 = (10 until 20).map(x => (x, x+1) )
       val rawEdges = sc.parallelize(chain1 ++ chain2, 3).map { case (s,d) => (s.toLong, d.toLong) }
-      val twoChains = Graph(rawEdges, true).reverse
+      val twoChains = Graph.fromEdgeTuples(rawEdges, true).reverse
       val ccGraph = Analytics.connectedComponents(twoChains).cache()
       val vertices = ccGraph.vertices.collect
       for ( (id, cc) <- vertices ) {
@@ -181,7 +181,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
   test("Count a single triangle") {
     withSpark(new SparkContext("local", "test")) { sc =>
       val rawEdges = sc.parallelize(Array( 0L->1L, 1L->2L, 2L->0L ), 2)
-      val graph = Graph(rawEdges, true).cache
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
       val triangleCount = Analytics.triangleCount(graph)
       val verts = triangleCount.vertices
       verts.collect.foreach { case (vid, count) => assert(count === 1) }
@@ -193,10 +193,10 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
       val triangles = Array(0L -> 1L, 1L -> 2L, 2L -> 0L) ++
         Array(0L -> -1L, -1L -> -2L, -2L -> 0L)
       val rawEdges = sc.parallelize(triangles, 2)
-      val graph = Graph(rawEdges, true).cache
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
       val triangleCount = Analytics.triangleCount(graph)
       val verts = triangleCount.vertices
-      verts.collect.foreach { case (vid, count) =>
+      verts.collect().foreach { case (vid, count) =>
         if (vid == 0) {
           assert(count === 2)
         } else {
@@ -213,10 +213,10 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
         Array(0L -> -1L, -1L -> -2L, -2L -> 0L)
       val revTriangles = triangles.map { case (a,b) => (b,a) }
       val rawEdges = sc.parallelize(triangles ++ revTriangles, 2)
-      val graph = Graph(rawEdges, true).cache
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
       val triangleCount = Analytics.triangleCount(graph)
       val verts = triangleCount.vertices
-      verts.collect.foreach { case (vid, count) =>
+      verts.collect().foreach { case (vid, count) =>
         if (vid == 0) {
           assert(count === 4)
         } else {
@@ -230,7 +230,7 @@ class AnalyticsSuite extends FunSuite with LocalSparkContext {
     withSpark(new SparkContext("local", "test")) { sc =>
       val rawEdges = sc.parallelize(Array(0L -> 1L, 1L -> 2L, 2L -> 0L) ++
         Array(0L -> 1L, 1L -> 2L, 2L -> 0L), 2)
-      val graph = Graph(rawEdges, true).cache
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
       val triangleCount = Analytics.triangleCount(graph)
       val verts = triangleCount.vertices
       verts.collect.foreach { case (vid, count) => assert(count === 1) }

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -136,12 +136,17 @@ class GraphSuite extends FunSuite with LocalSparkContext {
 
   test("subgraph") {
     withSpark(new SparkContext("local", "test")) { sc =>
+      // Create a star graph of 10 veritces.
       val n = 10
-      val star = Graph(sc.parallelize((1 to n).map(x => (0: Vid, x: Vid))), "defaultValue")
+      val star = Graph.fromEdgeTuples(sc.parallelize((1 to n).map(x => (0: Vid, x: Vid))), "v")
+      // Take only vertices whose vids are even
       val subgraph = star.subgraph(vpred = (vid, attr) => vid % 2 == 0)
-      assert(subgraph.vertices.collect().toSet ===
-        (0 to n / 2).map(x => (x * 2, "defaultValue")).toSet)
-      assert(subgraph.edges.collect().toSet === (1 to n / 2).map(x => Edge(0, x * 2)).toSet)
+
+      // We should have 5 vertices.
+      assert(subgraph.vertices.collect().toSet === (0 to n / 2).map(x => (x * 2, "v")).toSet)
+
+      // And 4 edges.
+      assert(subgraph.edges.map(_.copy()).collect().toSet === (1 to n / 2).map(x => Edge(0, x * 2, 1)).toSet)
     }
   }
 

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -20,15 +20,6 @@ class GraphSuite extends FunSuite with LocalSparkContext {
     }
   }
 
-  test("mapReduceTriplets") {
-    withSpark(new SparkContext("local", "test")) { sc =>
-      val edges = sc.parallelize((0L to 100L).zip((1L to 99L) :+ 0L))
-      val graph = Graph.fromEdgeTuples(edges, 1.0F)
-
-      val d = graph.mapReduceTriplets[Int](et => Iterator((et.srcId, 0)), (a, b) => a + b)
-    }
-  }
-
   test("Graph Creation with invalid vertices") {
     withSpark(new SparkContext("local", "test")) { sc =>
       val rawEdges = (0L to 98L).zip((1L to 99L) :+ 0L)
@@ -63,13 +54,6 @@ class GraphSuite extends FunSuite with LocalSparkContext {
     withSpark(new SparkContext("local", "test")) { sc =>
       val n = 3
       val star = Graph.fromEdgeTuples(sc.parallelize((1 to n).map(x => (0: Vid, x: Vid))), 0)
-
-      println("--------------------------------------- star vertices")
-      println(star.vertices.partitionsRDD.map { v => v.index.toString }.collect().toSeq)
-
-      println("---------------------------------------  starDeg")
-      println(star.degrees.partitionsRDD.map { v => v.index.toString }.collect().toSeq)
-
       val starDeg = star.joinVertices(star.degrees){ (vid, oldV, deg) => deg }
       val neighborDegreeSums = starDeg.mapReduceTriplets(
         edge => Iterator((edge.srcId, edge.dstAttr), (edge.dstId, edge.srcAttr)),

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -137,7 +137,7 @@ class GraphSuite extends FunSuite with LocalSparkContext {
   test("VertexSetRDD") {
     withSpark(new SparkContext("local", "test")) { sc =>
       val a = sc.parallelize((0 to 100).map(x => (x.toLong, x.toLong)), 5)
-      val b = VertexSetRDD(a).mapValues(x => -x)
+      val b = VertexSetRDD(a).mapValues(x => -x).cache() // Allow joining b with a derived RDD of b
       assert(b.count === 101)
       assert(b.leftJoin(a){ (id, a, bOpt) => a + bOpt.get }.map(x=> x._2).reduce(_+_) === 0)
       val c = b.aggregateUsingIndex[Long, (Long, Long)](a, (x, y) => x)

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -139,6 +139,7 @@ class GraphSuite extends FunSuite with LocalSparkContext {
       val subgraph = star.subgraph(vpred = (vid, attr) => vid % 2 == 0)
       assert(subgraph.vertices.collect().toSet ===
         (0 to n / 2).map(x => (x * 2, "defaultValue")).toSet)
+      assert(subgraph.edges.collect().toSet === (1 to n / 2).map(x => Edge(0, x * 2)).toSet)
     }
   }
 

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -132,4 +132,14 @@ class GraphSuite extends FunSuite with LocalSparkContext {
     }
   }
 
+  test("subgraph") {
+    withSpark(new SparkContext("local", "test")) { sc =>
+      val n = 10
+      val star = Graph(sc.parallelize((1 to n).map(x => (0: Vid, x: Vid))), "defaultValue")
+      val subgraph = star.subgraph(vpred = (vid, attr) => vid % 2 == 0)
+      assert(subgraph.vertices.collect().toSet ===
+        (0 to n / 2).map(x => (x * 2, "defaultValue")).toSet)
+    }
+  }
+
 }

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -121,7 +121,7 @@ class GraphSuite extends FunSuite with LocalSparkContext {
   test("VertexSetRDD") {
     withSpark(new SparkContext("local", "test")) { sc =>
       val a = sc.parallelize((0 to 100).map(x => (x.toLong, x.toLong)), 5)
-      val b = VertexSetRDD(a).mapValues(x => -x).cache() // Allow joining b with a derived RDD of b
+      val b = VertexRDD(a).mapValues(x => -x).cache() // Allow joining b with a derived RDD of b
       assert(b.count === 101)
       assert(b.leftJoin(a){ (id, a, bOpt) => a + bOpt.get }.map(x=> x._2).reduce(_+_) === 0)
       val c = b.aggregateUsingIndex[Long, (Long, Long)](a, (x, y) => x)


### PR DESCRIPTION
I refactored the code substantially, and now all the Vertex partition specific implementation is encapsulated in VertexPartition, and GraphImpl / VertexSetRDD (renamed VertexRDD) don't operate on bitmaps anymore.

Also added an EdgeRDD[ED] class to replace the previous RDD[Edge[ED]].
