### PR TITLE
Removed reindex from subgraph operator.

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -193,9 +193,9 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       epred: EdgeTriplet[VD, ED] => Boolean = (x => true),
       vpred: (Vid, VD) => Boolean = ((a,b) => true)): Graph[VD, ED] = {
 
-    // Filter the vertices, reusing the partitioner (but not the index) from
+    // Filter the vertices, reusing the partitioner and index from
     // this graph
-    val newVTable = vTable.mapVertexPartitions(_.filter(vpred).reindex())
+    val newVTable = vTable.mapVertexPartitions(_.filter(vpred))
 
     // Restrict the set of edges to those that satisfy the vertex and the edge predicate.
     val newETable = createETable(


### PR DESCRIPTION
In the general case we don't want to re-index the resulting graph after performing a subgraph operation. Reindexing means that we can't efficiently join the subgraph back with the original graph, a common operation.
