### PR TITLE
In mapReduceTriplets, walk vertices instead of edges

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/Edge.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Edge.scala
@@ -1,6 +1,5 @@
 package org.apache.spark.graph
 
-
 /**
  * A single directed edge consisting of a source id, target id,
  * and the data associated with the Edgee.
@@ -40,4 +39,11 @@ case class Edge[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) ED] 
    */
   def relativeDirection(vid: Vid): EdgeDirection =
     if (vid == srcId) EdgeDirection.Out else { assert(vid == dstId); EdgeDirection.In }
+}
+
+object Edge {
+  def lexicographicOrdering[ED] = new Ordering[Edge[ED]] {
+    override def compare(a: Edge[ED], b: Edge[ED]): Int =
+      Ordering[(Vid, Vid)].compare((a.srcId, a.dstId), (b.srcId, b.dstId))
+  }
 }

--- a/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
@@ -177,12 +177,6 @@ class VertexRDD[@specialized VD: ClassManifest](
   def mapValues[VD2: ClassManifest](f: (Vid, VD) => VD2): VertexRDD[VD2] =
     this.mapVertexPartitions(_.map(f))
 
-  def diff(other: VertexRDD[VD]): VertexRDD[VD] = {
-    this.zipVertexPartitions(other) { (thisPart, otherPart) =>
-      thisPart.diff(otherPart)
-    }
-  }
-
   /**
    * Inner join this VertexSet with another VertexSet which has the
    * same Index.  This function will fail if both VertexSets do not

--- a/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartitionBuilder.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartitionBuilder.scala
@@ -5,7 +5,7 @@ import org.apache.spark.util.collection.PrimitiveVector
 
 
 //private[graph]
-class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassManifest] {
+class EdgePartitionBuilder[ED: ClassManifest] {
 
   val srcIds = new PrimitiveVector[Vid]
   val dstIds = new PrimitiveVector[Vid]
@@ -19,6 +19,6 @@ class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassManifest] {
   }
 
   def toEdgePartition: EdgePartition[ED] = {
-    new EdgePartition(srcIds.trim().array, dstIds.trim().array, dataBuilder.trim().array)
+    new EdgePartition(srcIds.trim().array, dstIds.trim().array, dataBuilder.trim().array, false)
   }
 }

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -210,7 +210,7 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
 
       // Iterate over the active vertices
       val et = new EdgeTriplet[VD, ED](vertexPartition)
-      val activeFraction = vertexPartition.size / vertexPartition.capacity
+      val activeFraction = vertexPartition.size / vertexPartition.capacity.toFloat
       val mapOutputs =
         if (activeFraction < 0.5) {
           vertexPartition.edgePositionIterator.flatMap {

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -210,9 +210,10 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
 
       // Iterate over the active vertices
       val et = new EdgeTriplet[VD, ED](vertexPartition)
-      val activeFraction = vertexPartition.size / vertexPartition.capacity.toFloat
+      val activeFraction = vertexPartition.size / vertexPartition.index.size.toFloat
       val mapOutputs =
         if (activeFraction < 0.5) {
+          // println("Using vertex walking; activeFraction=%f".format(activeFraction))
           vertexPartition.edgePositionIterator.flatMap {
             case (srcVid, srcAttr, srcEdgePosition) =>
               // println("Looking at vertex %d --> index %d".format(srcVid, srcEdgePosition))
@@ -229,6 +230,7 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
               }
           }
         } else {
+          // println("Using edge walking; activeFraction=%f".format(activeFraction))
           edgePartition.iterator.flatMap { e =>
             et.set(e)
             if (mapUsesSrcAttr) {

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -113,7 +113,6 @@ class VTableReplicated[VD: ClassManifest](
           // println("Generating vTableReplicated for partition %d".format(pid))
           // println("vidToSrcEdgePosition:")
           // vidToSrcEdgePosition.iterator.foreach(pair => println("  " + pair))
-          // TODO(ankurdave): Fill srcEdgePositions with -1 by default, and check for that case
           val srcEdgePositions = Array.fill(vidToIndex.capacity)(-1)
           vidToSrcEdgePosition.iterator.foreach {
             case (vid, srcEdgePosition) =>

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -2,6 +2,7 @@ package org.apache.spark.graph.impl
 
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.util.collection.PrimitiveKeyOpenHashMap
 import org.apache.spark.util.collection.{PrimitiveVector, OpenHashSet}
 
 import org.apache.spark.graph._
@@ -73,17 +74,30 @@ class VTableReplicated[VD: ClassManifest](
         val localVidMap = eTable.partitionsRDD.mapPartitions(_.map {
           case (pid, epart) =>
             val vidToIndex = new VertexIdToIndexMap
+            val vidToSrcEdgePosition = new PrimitiveKeyOpenHashMap[Long, Int]
+            assert(epart.sorted)
+            // println("Generating localVidMap for partition %d".format(pid))
+            var currentSrcId: Vid = -1
+            var i = 0
             epart.foreach { e =>
+              if (e.srcId != currentSrcId || i == 0) {
+                // println("  [%d] Edge (%d, %d) is the start of a new block".format(i, e.srcId, e.dstId))
+                currentSrcId = e.srcId
+                vidToSrcEdgePosition.update(e.srcId, i)
+              } else {
+                // println("  [%d] Edge (%d, %d)".format(i, e.srcId, e.dstId))
+              }
               vidToIndex.add(e.srcId)
               vidToIndex.add(e.dstId)
+              i += 1
             }
-            (pid, vidToIndex)
+            (pid, (vidToIndex, vidToSrcEdgePosition))
         }, preservesPartitioning = true).cache()
 
         // Within each edge partition, place the vertex attributes received from
         // msgsByPartition into the correct locations specified in localVidMap
         localVidMap.zipPartitions(msgsByPartition) { (mapIter, msgsIter) =>
-          val (pid, vidToIndex) = mapIter.next()
+          val (pid, (vidToIndex, vidToSrcEdgePosition)) = mapIter.next()
           assert(!mapIter.hasNext)
           // Populate the vertex array using the vidToIndex map
           val vertexArray = vdManifest.newArray(vidToIndex.capacity)
@@ -91,11 +105,26 @@ class VTableReplicated[VD: ClassManifest](
             for (i <- 0 until block.vids.size) {
               val vid = block.vids(i)
               val attr = block.attrs(i)
-              val ind = vidToIndex.getPos(vid) & OpenHashSet.POSITION_MASK
+              val ind = vidToIndex.getPos(vid)
               vertexArray(ind) = attr
             }
           }
-          Iterator((pid, new VertexPartition(vidToIndex, vertexArray, vidToIndex.getBitSet)(vdManifest)))
+          // Populate the map from vid to source edge position in the edge partition
+          // println("Generating vTableReplicated for partition %d".format(pid))
+          // println("vidToSrcEdgePosition:")
+          // vidToSrcEdgePosition.iterator.foreach(pair => println("  " + pair))
+          // TODO(ankurdave): Fill srcEdgePositions with -1 by default, and check for that case
+          val srcEdgePositions = Array.fill(vidToIndex.capacity)(-1)
+          vidToSrcEdgePosition.iterator.foreach {
+            case (vid, srcEdgePosition) =>
+              if (vidToIndex.getPos(vid) != -1) {
+                val ind = vidToIndex.getPos(vid)
+                // println("  Inserting edge index for vertex %d (local index %d) --> %d".format(vid, ind, srcEdgePosition))
+                srcEdgePositions(ind) = srcEdgePosition
+              }
+          }
+          Iterator((pid, new VertexPartition(
+            vidToIndex, vertexArray, vidToIndex.getBitSet, srcEdgePositions)(vdManifest)))
         }.cache()
     }
   }


### PR DESCRIPTION
This greatly improves performance in Pregel when the active set is small, such as in the later stages of connected components.

To do:
- Support walking destination vertices as well as source vertices.
- ~~Dynamically switch between the two strategies based on the size of the active set.~~ (done)
- Fix GraphSuite.deltaJoinVertices test failure caused by a change in the semantics of graph.deltaJoinVertices.mapReduceTriplets
