### PR TITLE
Added BoundedPriorityQueue kryo registrator. Fixes top issue.

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphKryoRegistrator.scala
@@ -5,6 +5,7 @@ import com.esotericsoftware.kryo.Kryo
 import org.apache.spark.graph.impl._
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.spark.util.collection.BitSet
+import org.apache.spark.util.BoundedPriorityQueue
 
 
 class GraphKryoRegistrator extends KryoRegistrator {
@@ -19,6 +20,7 @@ class GraphKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[VertexIdToIndexMap])
     kryo.register(classOf[VertexAttributeBlock[Object]])
     kryo.register(classOf[PartitionStrategy])
+    kryo.register(classOf[BoundedPriorityQueue[Object]])
 
     // This avoids a large number of hash table lookups.
     kryo.setReferences(false)


### PR DESCRIPTION
Without this change, BoundedPriorityQueue gets deserialized to the wrong top and causes ClassCastExceptions when calling RDD.top()
