### PR TITLE
Support activeSet option in mapReduceTriplets

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/EdgeRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/EdgeRDD.scala
@@ -40,20 +40,18 @@ class EdgeRDD[@specialized ED: ClassManifest](
 
   def mapEdgePartitions[ED2: ClassManifest](f: EdgePartition[ED] => EdgePartition[ED2])
     : EdgeRDD[ED2]= {
-    val cleanF = sparkContext.clean(f)
     new EdgeRDD[ED2](partitionsRDD.mapPartitions({ iter =>
       val (pid, ep) = iter.next()
-      Iterator(Tuple2(pid, cleanF(ep)))
+      Iterator(Tuple2(pid, f(ep)))
     }, preservesPartitioning = true))
   }
 
   def zipEdgePartitions[T: ClassManifest, U: ClassManifest]
       (other: RDD[T])
       (f: (EdgePartition[ED], Iterator[T]) => Iterator[U]): RDD[U] = {
-    val cleanF = sparkContext.clean(f)
     partitionsRDD.zipPartitions(other, preservesPartitioning = true) { (ePartIter, otherIter) =>
       val (_, edgePartition) = ePartIter.next()
-      cleanF(edgePartition, otherIter)
+      f(edgePartition, otherIter)
     }
   }
 

--- a/graph/src/main/scala/org/apache/spark/graph/EdgeTriplet.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/EdgeTriplet.scala
@@ -28,6 +28,9 @@ class EdgeTriplet[VD, ED] extends Edge[ED] {
    */
   var dstAttr: VD = _ //nullValue[VD]
 
+  var srcStale: Boolean = false
+  var dstStale: Boolean = false
+
   /**
    * Set the edge properties of this triplet.
    */

--- a/graph/src/main/scala/org/apache/spark/graph/EdgeTriplet.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/EdgeTriplet.scala
@@ -13,7 +13,7 @@ import org.apache.spark.graph.impl.VertexPartition
  * tried specializing I got a warning about inherenting from a type
  * that is not a trait.
  */
-class EdgeTriplet[VD, ED](vPart: VertexPartition[VD] = null) extends Edge[ED] {
+class EdgeTriplet[VD, ED] extends Edge[ED] {
 // class EdgeTriplet[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) VD: ClassManifest,
 //                   @specialized(Char, Int, Boolean, Byte, Long, Float, Double) ED: ClassManifest] extends Edge[ED] {
 
@@ -27,9 +27,6 @@ class EdgeTriplet[VD, ED](vPart: VertexPartition[VD] = null) extends Edge[ED] {
    * The destination vertex attribute
    */
   var dstAttr: VD = _ //nullValue[VD]
-
-  def srcMask: Boolean = vPart.isDefined(srcId)
-  def dstMask: Boolean = vPart.isDefined(dstId)
 
   /**
    * Set the edge properties of this triplet.

--- a/graph/src/main/scala/org/apache/spark/graph/Graph.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Graph.scala
@@ -281,9 +281,12 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
     : Graph[VD2, ED]
 
   /**
-   * Replace vertices in the graph with corresponding vertices in `updates`.
+   * Replace vertices in the graph with corresponding vertices in `updates`, and restrict vertices
+   * without a corresponding vertex in `updates`. Edges adjacent to restricted vertices will still
+   * appear in graph.edges, but not in triplets or mapReduceTriplets.
    */
-  def updateVertices(updates: VertexRDD[VD]): Graph[VD, ED]
+  def innerJoinVertices[U: ClassManifest, VD2: ClassManifest](table: RDD[(Vid, U)])
+      (f: (Vid, VD, U) => VD2): Graph[VD2, ED]
 
   // Save a copy of the GraphOps object so there is always one unique GraphOps object
   // for a given Graph object, and thus the lazy vals in GraphOps would work as intended.

--- a/graph/src/main/scala/org/apache/spark/graph/Graph.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Graph.scala
@@ -242,7 +242,9 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
    */
   def mapReduceTriplets[A: ClassManifest](
       mapFunc: EdgeTriplet[VD, ED] => Iterator[(Vid, A)],
-      reduceFunc: (A, A) => A)
+      reduceFunc: (A, A) => A,
+      skipStaleSrc: Boolean = false,
+      skipStaleDst: Boolean = false)
     : VertexRDD[A]
 
   /**
@@ -278,7 +280,10 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
       (mapFunc: (Vid, VD, Option[U]) => VD2)
     : Graph[VD2, ED]
 
-  def deltaJoinVertices(changedVerts: VertexRDD[VD]): Graph[VD, ED]
+  /**
+   * Replace vertices in the graph with corresponding vertices in `updates`.
+   */
+  def updateVertices(updates: VertexRDD[VD]): Graph[VD, ED]
 
   // Save a copy of the GraphOps object so there is always one unique GraphOps object
   // for a given Graph object, and thus the lazy vals in GraphOps would work as intended.

--- a/graph/src/main/scala/org/apache/spark/graph/Graph.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Graph.scala
@@ -225,6 +225,11 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
    * be commutative and assosciative and is used to combine the output
    * of the map phase.
    *
+   * @param activeSet optionally, a set of "active" vertices and a direction of edges to consider
+   * when running `mapFunc`. For example, if the direction is Out, `mapFunc` will only be run on
+   * edges originating from vertices in the active set. `activeSet` must have the same index as the
+   * graph's vertices.
+   *
    * @example We can use this function to compute the inDegree of each
    * vertex
    * {{{
@@ -243,8 +248,7 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
   def mapReduceTriplets[A: ClassManifest](
       mapFunc: EdgeTriplet[VD, ED] => Iterator[(Vid, A)],
       reduceFunc: (A, A) => A,
-      skipStaleSrc: Boolean = false,
-      skipStaleDst: Boolean = false)
+      activeSetOpt: Option[(VertexRDD[_], EdgeDirection)] = None)
     : VertexRDD[A]
 
   /**
@@ -279,14 +283,6 @@ abstract class Graph[VD: ClassManifest, ED: ClassManifest] {
   def outerJoinVertices[U: ClassManifest, VD2: ClassManifest](table: RDD[(Vid, U)])
       (mapFunc: (Vid, VD, Option[U]) => VD2)
     : Graph[VD2, ED]
-
-  /**
-   * Replace vertices in the graph with corresponding vertices in `updates`, and restrict vertices
-   * without a corresponding vertex in `updates`. Edges adjacent to restricted vertices will still
-   * appear in graph.edges, but not in triplets or mapReduceTriplets.
-   */
-  def innerJoinVertices[U: ClassManifest, VD2: ClassManifest](table: RDD[(Vid, U)])
-      (f: (Vid, VD, U) => VD2): Graph[VD2, ED]
 
   // Save a copy of the GraphOps object so there is always one unique GraphOps object
   // for a given Graph object, and thus the lazy vals in GraphOps would work as intended.

--- a/graph/src/main/scala/org/apache/spark/graph/GraphOps.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/GraphOps.scala
@@ -2,7 +2,6 @@ package org.apache.spark.graph
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext._
-import org.apache.spark.util.ClosureCleaner
 import org.apache.spark.SparkException
 
 
@@ -116,9 +115,6 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
       dir: EdgeDirection)
     : VertexRDD[A] = {
 
-    ClosureCleaner.clean(mapFunc)
-    ClosureCleaner.clean(reduceFunc)
-
     // Define a new map function over edge triplets
     val mf = (et: EdgeTriplet[VD,ED]) => {
       // Compute the message to the dst vertex
@@ -140,7 +136,6 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
       }
     }
 
-    ClosureCleaner.clean(mf)
     graph.mapReduceTriplets(mf, reduceFunc)
   } // end of aggregateNeighbors
 
@@ -233,7 +228,6 @@ class GraphOps[VD: ClassManifest, ED: ClassManifest](graph: Graph[VD, ED]) {
    */
   def joinVertices[U: ClassManifest](table: RDD[(Vid, U)])(mapFunc: (Vid, VD, U) => VD)
     : Graph[VD, ED] = {
-    ClosureCleaner.clean(mapFunc)
     val uf = (id: Vid, data: VD, o: Option[U]) => {
       o match {
         case Some(u) => mapFunc(id, data, u)

--- a/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
@@ -107,9 +107,9 @@ object Pregel {
     var i = 0
     while (activeMessages > 0 && i < maxIterations) {
       // receive the messages
-      val changedVerts = g.vertices.deltaJoin(messages)(vprog).cache() // updating the vertices
+      val changedVerts = g.vertices.zipJoin(messages)(vprog).cache() // updating the vertices
       // replicate the changed vertices
-      g = g.deltaJoinVertices(changedVerts)
+      g = g.updateVertices(changedVerts)
 
       val oldMessages = messages
       // compute the messages

--- a/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
@@ -92,29 +92,22 @@ object Pregel {
     : Graph[VD, ED] = {
 
     var g = graph.mapVertices( (vid, vdata) => vprog(vid, vdata, initialMsg) )
-    println("[pre] g: " + g.vertices.cache().collect.mkString(","))
     // compute the messages
     var messages = g.mapReduceTriplets(sendMsg, mergeMsg).cache()
-    println("[pre] messages: " + messages.collect.mkString(","))
     var activeMessages = messages.count()
-    println("Pregel pre-run, %d active messages".format(activeMessages))
     // Loop
     var i = 0
     while (activeMessages > 0 && i < maxIterations) {
       // Receive the messages. Vertices that didn't get any messages do not appear in newVerts.
       val newVerts = g.vertices.innerJoin(messages)(vprog).cache()
-      println("newVerts: " + newVerts.collect.mkString(","))
       // Update the graph with the new vertices.
       g = g.outerJoinVertices(newVerts) { (vid, old, newOpt) => newOpt.getOrElse(old) }
-      println("g: " + g.vertices.cache().collect.mkString(","))
 
       val oldMessages = messages
       // Send new messages. Vertices that didn't get any messages don't appear in newVerts, so don't
       // get to send messages.
       messages = g.mapReduceTriplets(sendMsg, mergeMsg, Some((newVerts, EdgeDirection.Out))).cache()
-      println("messages: " + messages.collect.mkString(","))
       activeMessages = messages.count()
-      println("Pregel iter %d, %d active messages".format(i, activeMessages))
       // after counting we can unpersist the old messages
       oldMessages.unpersist(blocking=false)
       // count the iteration

--- a/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/Pregel.scala
@@ -91,17 +91,9 @@ object Pregel {
       mergeMsg: (A, A) => A)
     : Graph[VD, ED] = {
 
-    def sendMsgFun(edge: EdgeTriplet[VD, ED]): Iterator[(Vid, A)] = {
-      if (edge.srcMask) {
-        sendMsg(edge)
-      } else {
-        Iterator.empty
-      }
-    }
-
     var g = graph.mapVertices( (vid, vdata) => vprog(vid, vdata, initialMsg) )
     // compute the messages
-    var messages = g.mapReduceTriplets(sendMsgFun, mergeMsg).cache()
+    var messages = g.mapReduceTriplets(sendMsg, mergeMsg).cache()
     var activeMessages = messages.count()
     // Loop
     var i = 0
@@ -113,7 +105,7 @@ object Pregel {
 
       val oldMessages = messages
       // compute the messages
-      messages = g.mapReduceTriplets(sendMsgFun, mergeMsg).cache()
+      messages = g.mapReduceTriplets(sendMsg, mergeMsg).cache()
       activeMessages = messages.count()
       // after counting we can unpersist the old messages
       oldMessages.unpersist(blocking=false)

--- a/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
@@ -113,8 +113,7 @@ class VertexRDD[@specialized VD: ClassManifest](
    */
   def mapVertexPartitions[VD2: ClassManifest](f: VertexPartition[VD] => VertexPartition[VD2])
     : VertexRDD[VD2] = {
-    val cleanF = sparkContext.clean(f)
-    val newPartitionsRDD = partitionsRDD.mapPartitions(_.map(cleanF), preservesPartitioning = true)
+    val newPartitionsRDD = partitionsRDD.mapPartitions(_.map(f), preservesPartitioning = true)
     new VertexRDD(newPartitionsRDD)
   }
 
@@ -125,13 +124,12 @@ class VertexRDD[@specialized VD: ClassManifest](
   private def zipVertexPartitions[VD2: ClassManifest, VD3: ClassManifest]
     (other: VertexRDD[VD2])
     (f: (VertexPartition[VD], VertexPartition[VD2]) => VertexPartition[VD3]): VertexRDD[VD3] = {
-    val cleanF = sparkContext.clean(f)
     val newPartitionsRDD = partitionsRDD.zipPartitions(
       other.partitionsRDD, preservesPartitioning = true
     ) { (thisIter, otherIter) =>
       val thisPart = thisIter.next()
       val otherPart = otherIter.next()
-      Iterator(cleanF(thisPart, otherPart))
+      Iterator(f(thisPart, otherPart))
     }
     new VertexRDD(newPartitionsRDD)
   }

--- a/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
@@ -288,7 +288,7 @@ class VertexRDD[@specialized VD: ClassManifest](
 
   /**
    * Replace vertices with corresponding vertices in `other`, and drop vertices without a
-   * corresponding vertex in `other.
+   * corresponding vertex in `other`.
    */
   def innerJoin[U: ClassManifest, VD2: ClassManifest](other: RDD[(Vid, U)])
       (f: (Vid, VD, U) => VD2): VertexRDD[VD2] = {

--- a/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
@@ -121,7 +121,7 @@ class VertexRDD[@specialized VD: ClassManifest](
    * Return a new VertexRDD by applying a function to corresponding
    * VertexPartitions of this VertexRDD and another one.
    */
-  private def zipVertexPartitions[VD2: ClassManifest, VD3: ClassManifest]
+  def zipVertexPartitions[VD2: ClassManifest, VD3: ClassManifest]
     (other: VertexRDD[VD2])
     (f: (VertexPartition[VD], VertexPartition[VD2]) => VertexPartition[VD3]): VertexRDD[VD3] = {
     val newPartitionsRDD = partitionsRDD.zipPartitions(
@@ -298,7 +298,7 @@ class VertexRDD[@specialized VD: ClassManifest](
       case other: VertexRDD[_] =>
         innerZipJoin(other)(f)
       case _ =>
-        new VertexRDD[VD](
+        new VertexRDD(
           partitionsRDD.zipPartitions(
             other.partitionBy(this.partitioner.get), preservesPartitioning = true)
           { (part, msgs) =>

--- a/graph/src/main/scala/org/apache/spark/graph/algorithms/PageRank.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/algorithms/PageRank.scala
@@ -178,7 +178,7 @@ object PageRank extends Logging {
         .mapReduceTriplets[Double](
           et => Iterator((et.dstId, et.srcAttr * et.attr * weight)),
           _ + _,
-          prevDeltas.map(d => (d, EdgeDirection.Out)))
+          prevDeltas.map((_, EdgeDirection.Out)))
         .filter { case (vid, delta) => delta > tol }
         .cache()
       prevDeltas = Some(deltas)

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -223,7 +223,7 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       val (_, vertexPartition) = vTableReplicatedIter.next()
 
       // Iterate over the partition
-      val et = new EdgeTriplet[VD, ED](vertexPartition)
+      val et = new EdgeTriplet[VD, ED]
       val filteredEdges = edgePartition.iterator.flatMap { e =>
         // Ensure that the edge meets the requirements of skipStaleSrc and skipStaleDst
         val srcVertexOK = !skipStaleSrc || vertexPartition.isDefined(e.srcId)

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -226,9 +226,9 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       val et = new EdgeTriplet[VD, ED]
       val filteredEdges = edgePartition.iterator.flatMap { e =>
         // Ensure that the edge meets the requirements of skipStaleSrc and skipStaleDst
-        val srcVertexOK = !skipStaleSrc || vertexPartition.isDefined(e.srcId)
-        val dstVertexOK = !skipStaleDst || vertexPartition.isDefined(e.dstId)
-        if (srcVertexOK && dstVertexOK) {
+        val skipDueToSrc = skipStaleSrc && vertexPartition.isStale(e.srcId)
+        val skipDueToDst = skipStaleDst && vertexPartition.isStale(e.dstId)
+        if (!skipDueToSrc && !skipDueToDst) {
           et.set(e)
           if (mapUsesSrcAttr) {
             et.srcAttr = vertexPartition(e.srcId)

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -137,7 +137,7 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       val newVerts = vertices.mapVertexPartitions(_.map(f))
       val changedVerts = vertices.asInstanceOf[VertexRDD[VD2]].diff(newVerts)
       val newVTableReplicated = new VTableReplicated[VD2](
-        newVerts, edges, vertexPlacement,
+        changedVerts, edges, vertexPlacement,
         Some(vTableReplicated.asInstanceOf[VTableReplicated[VD2]]))
       new GraphImpl(newVerts, edges, vertexPlacement, newVTableReplicated)
     } else {
@@ -256,7 +256,7 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       val newVerts = vertices.leftJoin(updates)(updateF)
       val changedVerts = vertices.asInstanceOf[VertexRDD[VD2]].diff(newVerts)
       val newVTableReplicated = new VTableReplicated[VD2](
-        newVerts, edges, vertexPlacement,
+        changedVerts, edges, vertexPlacement,
         Some(vTableReplicated.asInstanceOf[VTableReplicated[VD2]]))
       new GraphImpl(newVerts, edges, vertexPlacement, newVTableReplicated)
     } else {

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -226,8 +226,10 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
       val et = new EdgeTriplet[VD, ED]
       val filteredEdges = edgePartition.iterator.flatMap { e =>
         // Ensure that the edge meets the requirements of skipStaleSrc and skipStaleDst
-        val skipDueToSrc = skipStaleSrc && vertexPartition.isStale(e.srcId)
-        val skipDueToDst = skipStaleDst && vertexPartition.isStale(e.dstId)
+        et.srcStale = vertexPartition.isStale(e.srcId)
+        et.dstStale = vertexPartition.isStale(e.dstId)
+        val skipDueToSrc = skipStaleSrc && et.srcStale
+        val skipDueToDst = skipStaleDst && et.dstStale
         if (!skipDueToSrc && !skipDueToDst) {
           et.set(e)
           if (mapUsesSrcAttr) {

--- a/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/GraphImpl.scala
@@ -217,7 +217,8 @@ class GraphImpl[VD: ClassManifest, ED: ClassManifest] protected (
 
     // Map and combine.
     val preAgg = edges.zipEdgePartitions(vs) { (edgePartition, vTableReplicatedIter) =>
-      val (pid, vertexPartition) = vTableReplicatedIter.next()
+      val (_, vertexPartition) = vTableReplicatedIter.next()
+
       // Iterate over the partition
       val et = new EdgeTriplet[VD, ED]
       val filteredEdges = edgePartition.iterator.flatMap { e =>

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -69,7 +69,7 @@ class VTableReplicated[VD: ClassManifest](
     // also shipped there.
     val shippedActives = vertexPlacement.get(true, true)
       .zipPartitions(actives.partitionsRDD)(VTableReplicated.buildActiveBuffer(_, _))
-      .partitionBy(edges.partitioner.get)// .cache().setName("VTableReplicated shippedActives")
+      .partitionBy(edges.partitioner.get)
     // Update vTableReplicated with shippedActives, setting activeness flags in the resulting
     // VertexPartitions
     get(includeSrc, includeDst).zipPartitions(shippedActives) { (viewIter, shippedActivesIter) =>
@@ -87,7 +87,7 @@ class VTableReplicated[VD: ClassManifest](
     val verts = updatedVerts.partitionsRDD
     val shippedVerts = vertexPlacement.get(includeSrc, includeDst)
       .zipPartitions(verts)(VTableReplicated.buildBuffer(_, _)(vdManifest))
-      .partitionBy(edges.partitioner.get)// .cache().setName("VTableReplicated shippedVerts")
+      .partitionBy(edges.partitioner.get)
     // TODO: Consider using a specialized shuffler.
 
     prevVTableReplicated match {

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -79,8 +79,7 @@ class VTableReplicated[VD: ClassManifest](
         // VertexPartitions
         prevView.zipPartitions(shippedVerts) { (prevViewIter, shippedVertsIter) =>
           val (pid, prevVPart) = prevViewIter.next()
-          val newVPart = prevVPart.updateHideUnchanged(
-            shippedVertsIter.flatMap(_._2.iterator))
+          val newVPart = prevVPart.innerJoinKeepLeft(shippedVertsIter.flatMap(_._2.iterator))
           Iterator((pid, newVPart))
         }.cache().setName("VTableReplicated delta %s %s".format(includeSrcAttr, includeDstAttr))
 

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VTableReplicated.scala
@@ -23,21 +23,26 @@ class VTableReplicated[VD: ClassManifest](
     vertexPlacement: VertexPlacement,
     prevVTableReplicated: Option[VTableReplicated[VD]] = None) {
 
-  // Within each edge partition, create a local map from vid to an index into
-  // the attribute array. Each map contains a superset of the vertices that it
-  // will receive, because it stores vids from both the source and destination
-  // of edges. It must always include both source and destination vids because
-  // some operations, such as GraphImpl.mapReduceTriplets, rely on this.
-  val localVidMap: RDD[(Int, VertexIdToIndexMap)] = edges.partitionsRDD.mapPartitions(_.map {
-    case (pid, epart) =>
-      val vidToIndex = new VertexIdToIndexMap
-      epart.foreach { e =>
-        vidToIndex.add(e.srcId)
-        vidToIndex.add(e.dstId)
-      }
-      (pid, vidToIndex)
-  }, preservesPartitioning = true).cache()
-
+  /**
+   * Within each edge partition, create a local map from vid to an index into the attribute
+   * array. Each map contains a superset of the vertices that it will receive, because it stores
+   * vids from both the source and destination of edges. It must always include both source and
+   * destination vids because some operations, such as GraphImpl.mapReduceTriplets, rely on this.
+   */
+  private val localVidMap: RDD[(Int, VertexIdToIndexMap)] = prevVTableReplicated match {
+    case Some(prev) =>
+      prev.localVidMap
+    case None =>
+      edges.partitionsRDD.mapPartitions(_.map {
+        case (pid, epart) =>
+          val vidToIndex = new VertexIdToIndexMap
+          epart.foreach { e =>
+            vidToIndex.add(e.srcId)
+            vidToIndex.add(e.dstId)
+          }
+          (pid, vidToIndex)
+      }, preservesPartitioning = true).cache()
+  }
 
   val bothAttrs: RDD[(Pid, VertexPartition[VD])] = createVTableReplicated(true, true)
   val srcAttrOnly: RDD[(Pid, VertexPartition[VD])] = createVTableReplicated(true, false)

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
@@ -48,6 +48,15 @@ class VertexPartition[@specialized(Long, Int, Double) VD: ClassManifest](
   }
 
   /**
+   * A vertex is stale if it is present in the index but hidden by the mask. In contrast, a vertex
+   * is nonexistent (possibly due to join rewrite) if it is not present in the index at all.
+   */
+  def isStale(vid: Vid): Boolean = {
+    val pos = index.getPos(vid)
+    pos >= 0 && !mask.get(pos)
+  }
+
+  /**
    * Pass each vertex attribute along with the vertex id through a map
    * function and retain the original RDD's partitioning and index.
    *

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
@@ -174,6 +174,10 @@ class VertexPartition[@specialized(Long, Int, Double) VD: ClassManifest](
   /** Inner join another VertexPartition. */
   def innerJoin[U: ClassManifest, VD2: ClassManifest](other: VertexPartition[U])
       (f: (Vid, VD, U) => VD2): VertexPartition[VD2] = {
+    if (index != other.index) {
+      logWarning("Joining two VertexPartitions with different indexes is slow.")
+      innerJoin(createUsingIndex(other.iterator))(f)
+    }
     val newMask = mask & other.mask
     val newValues = new Array[VD2](capacity)
     var i = newMask.nextSetBit(0)

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
@@ -51,8 +51,7 @@ class VertexPartition[@specialized(Long, Int, Double) VD: ClassManifest](
 
   /** Look up vid in activeSet, throwing an exception if it is None. */
   def isActive(vid: Vid): Boolean = {
-    val pos = index.getPos(vid)
-    pos >= 0 && activeSet.get.contains(pos)
+    activeSet.get.contains(vid)
   }
 
   /**

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPartition.scala
@@ -108,17 +108,20 @@ class VertexPartition[@specialized(Long, Int, Double) VD: ClassManifest](
    * the values from `other`. The indices of `this` and `other` must be the same.
    */
   def diff(other: VertexPartition[VD]): VertexPartition[VD] = {
-    assert(index == other.index)
-
-    val newMask = mask & other.mask
-    var i = newMask.nextSetBit(0)
-    while (i >= 0) {
-      if (values(i) == other.values(i)) {
-        newMask.unset(i)
+    if (index != other.index) {
+      logWarning("Diffing two VertexPartitions with different indexes is slow.")
+      diff(createUsingIndex(other.iterator))
+    } else {
+      val newMask = mask & other.mask
+      var i = newMask.nextSetBit(0)
+      while (i >= 0) {
+        if (values(i) == other.values(i)) {
+          newMask.unset(i)
+        }
+        i = newMask.nextSetBit(i + 1)
       }
-      i = newMask.nextSetBit(i + 1)
+      new VertexPartition(index, other.values, newMask)
     }
-    new VertexPartition(index, other.values, newMask)
   }
 
   /** Inner join another VertexPartition. */

--- a/graph/src/main/scala/org/apache/spark/graph/impl/VertexPlacement.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/VertexPlacement.scala
@@ -7,8 +7,10 @@ import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.collection.PrimitiveVector
 
 /**
- * Stores the layout of replicated vertex attributes for GraphImpl. Tells each
- * partition of the vertex data where it should go.
+ * Stores the locations of edge-partition join sites for each vertex attribute in `vTable`; that is,
+ * the routing information for shipping vertex attributes to edge partitions. This is always cached
+ * because it may be used multiple times in VTableReplicated -- once to ship the vertex attributes
+ * and (possibly) once to ship the active-set information.
  */
 class VertexPlacement(eTable: EdgeRDD[_], vTable: VertexRDD[_]) {
 
@@ -24,13 +26,6 @@ class VertexPlacement(eTable: EdgeRDD[_], vTable: VertexRDD[_]) {
       case (false, true) => dstAttrOnly
       case (false, false) => noAttrs
     }
-
-  def persist(newLevel: StorageLevel) {
-    bothAttrs.persist(newLevel)
-    srcAttrOnly.persist(newLevel)
-    dstAttrOnly.persist(newLevel)
-    noAttrs.persist(newLevel)
-  }
 
   private def createPid2Vid(
       includeSrcAttr: Boolean, includeDstAttr: Boolean): RDD[Array[Array[Vid]]] = {

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -100,8 +100,6 @@ class GraphSuite extends FunSuite with LocalSparkContext {
         if (et.dstId % 2 != 0) {
           throw new Exception("map ran on edge with dst vid %d, which is odd".format(et.dstId))
         }
-        println(et.srcAttr)
-        println(et.dstAttr)
         Iterator((et.srcId, 1), (et.dstId, 1))
       }, (a: Int, b: Int) => a + b, skipStaleSrc = true, skipStaleDst = true).collect.toSet
       assert(numEvenNeighbors === (2 to n by 2).map(x => (x: Vid, n / 2 - 1)).toSet)

--- a/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/GraphSuite.scala
@@ -152,7 +152,7 @@ class GraphSuite extends FunSuite with LocalSparkContext {
     }
   }
 
-  test("deltaJoinVertices") {
+  test("updateVertices") {
     withSpark(new SparkContext("local", "test")) { sc =>
       // Create a star graph of 10 vertices
       val n = 10
@@ -162,7 +162,7 @@ class GraphSuite extends FunSuite with LocalSparkContext {
       val changedVerts = star.vertices.filter(_._1 % 2 == 0).mapValues((vid, attr) => "v2")
 
       // Apply the modification to the graph
-      val changedStar = star.deltaJoinVertices(changedVerts)
+      val changedStar = star.updateVertices(changedVerts)
 
       val newVertices = star.vertices.leftZipJoin(changedVerts) { (vid, oldVd, newVdOpt) =>
         newVdOpt match {

--- a/graph/src/test/scala/org/apache/spark/graph/PregelSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/PregelSuite.scala
@@ -1,0 +1,43 @@
+package org.apache.spark.graph
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.SparkContext
+import org.apache.spark.graph.LocalSparkContext._
+import org.apache.spark.rdd._
+
+class PregelSuite extends FunSuite with LocalSparkContext {
+
+  System.setProperty("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+  System.setProperty("spark.kryo.registrator", "org.apache.spark.graph.GraphKryoRegistrator")
+
+  test("1 iteration") {
+    withSpark(new SparkContext("local", "test")) { sc =>
+      val n = 5
+      val star = Graph.fromEdgeTuples(sc.parallelize((1 to n).map(x => (0: Vid, x: Vid)), 3), "v")
+      val result = Pregel(star, 0)(
+        (vid, attr, msg) => attr,
+        et => Iterator.empty,
+        (a: Int, b: Int) => throw new Exception("mergeMsg run unexpectedly"))
+      assert(result.vertices.collect.toSet === star.vertices.collect.toSet)
+    }
+  }
+
+  test("chain propagation") {
+    withSpark(new SparkContext("local", "test")) { sc =>
+      val n = 5
+      val chain = Graph.fromEdgeTuples(
+        sc.parallelize((1 until n).map(x => (x: Vid, x + 1: Vid)), 3),
+        0).cache()
+      assert(chain.vertices.collect.toSet === (1 to n).map(x => (x: Vid, 0)).toSet)
+      val chainWithSeed = chain.mapVertices { (vid, attr) => if (vid == 1) 1 else 0 }
+      assert(chainWithSeed.vertices.collect.toSet === Set((1: Vid, 1)) ++ (2 to n).map(x => (x: Vid, 0)).toSet)
+      val result = Pregel(chainWithSeed, 0)(
+        (vid, attr, msg) => { println("vprog on " + (vid, attr, msg)); math.max(msg, attr) },
+        et => { println("sendMsg on " + ((et.srcId, et.srcAttr), (et.dstId, et.dstAttr))); Iterator((et.dstId, et.srcAttr)) },
+        (a: Int, b: Int) => { println("mergeMsg on " + (a, b)); math.max(a, b) })
+      assert(result.vertices.collect.toSet ===
+        chain.vertices.mapValues { (vid, attr) => attr + 1 }.collect.toSet)
+    }
+  }
+}

--- a/graph/src/test/scala/org/apache/spark/graph/PregelSuite.scala
+++ b/graph/src/test/scala/org/apache/spark/graph/PregelSuite.scala
@@ -33,9 +33,9 @@ class PregelSuite extends FunSuite with LocalSparkContext {
       val chainWithSeed = chain.mapVertices { (vid, attr) => if (vid == 1) 1 else 0 }
       assert(chainWithSeed.vertices.collect.toSet === Set((1: Vid, 1)) ++ (2 to n).map(x => (x: Vid, 0)).toSet)
       val result = Pregel(chainWithSeed, 0)(
-        (vid, attr, msg) => { println("vprog on " + (vid, attr, msg)); math.max(msg, attr) },
-        et => { println("sendMsg on " + ((et.srcId, et.srcAttr), (et.dstId, et.dstAttr))); Iterator((et.dstId, et.srcAttr)) },
-        (a: Int, b: Int) => { println("mergeMsg on " + (a, b)); math.max(a, b) })
+        (vid, attr, msg) => math.max(msg, attr),
+        et => Iterator((et.dstId, et.srcAttr)),
+        (a: Int, b: Int) => math.max(a, b))
       assert(result.vertices.collect.toSet ===
         chain.vertices.mapValues { (vid, attr) => attr + 1 }.collect.toSet)
     }


### PR DESCRIPTION
Active set tracking (e.g., for Pregel) was previously inelegant. To perform changed-vertex tracking, the user had to change the vertices, then use VertexRDD.deltaJoin (to filter out unchanged vertices) followed by Graph.deltaJoinVertices (to update the graph with the changed vertices while masking out unchanged vertices _only in the join view_) followed by mapReduceTriplets, where the map UDF needed to check EdgeTriplet.srcMask to see if the source vertex was active before sending messages.

Moreover, Pregel was implemented incorrectly using this abstraction. Vertices whose attributes did not change from one iteration to the next but which continued to receive messages would not get a chance to run, because EdgeTriplet.srcMask reflected the fact that they were _unchanged_ rather than _inactive_.

Finally, the abstraction did not permit pushing the activeness check into the framework by performing a clustered index scan over the edges.

---

This PR simplifies the abstraction by removing Graph.deltaJoinVertices and instead adding an optional _activeSet_ parameter to mapReduceTriplets. This option takes a set of vertices with the same index as the graph's vertices and runs the map function only on edges neighboring a vertex in the active set. The direction of neighboring edges to consider can be specified by passing an EdgeDirection.

This is implemented by shipping OpenHashSet[Vid]s with the active vertex ids, and filtering edges in mapReduceTriplets by performing hash lookups in the set. Note that the active vertex id set cannot be represented as a bitmask over the join view, because the vertex index in the join view may not contain all relevant vertices due to join rewrite.

Staleness is still exposed using EdgeTriplet.srcStale and dstStale, but nothing currently uses it.
