### PR TITLE
Fixing Persist Behavior

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/EdgeRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/EdgeRDD.scala
@@ -33,7 +33,7 @@ class EdgeRDD[@specialized ED: ClassManifest](
    * Caching a VertexRDD causes the index and values to be cached separately.
    */
   override def persist(newLevel: StorageLevel): EdgeRDD[ED] = {
-    partitionsRDD.persist(newLevel)
+    super.persist(newLevel)
     this
   }
 

--- a/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
@@ -86,7 +86,7 @@ class VertexRDD[@specialized VD: ClassManifest](
    * Caching a VertexRDD causes the index and values to be cached separately.
    */
   override def persist(newLevel: StorageLevel): VertexRDD[VD] = {
-    super.persist(newLevel)
+    partitionsRDD.persist(newLevel)
     this
   }
 
@@ -105,7 +105,7 @@ class VertexRDD[@specialized VD: ClassManifest](
    * Provide the `RDD[(Vid, VD)]` equivalent output.
    */
   override def compute(part: Partition, context: TaskContext): Iterator[(Vid, VD)] = {
-    partitionsRDD.compute(part, context).next().iterator
+    firstParent[VertexPartition[VD]].iterator(part, context).next.iterator
   }
 
   /**

--- a/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/VertexRDD.scala
@@ -86,7 +86,7 @@ class VertexRDD[@specialized VD: ClassManifest](
    * Caching a VertexRDD causes the index and values to be cached separately.
    */
   override def persist(newLevel: StorageLevel): VertexRDD[VD] = {
-    partitionsRDD.persist(newLevel)
+    super.persist(newLevel)
     this
   }
 


### PR DESCRIPTION
The persist behavior of the current Vertex and Edge RDDs persist the pervious RDD (recursively?) instead of the current RDD.  This is addressed by instead calling the persist on the parent RDD class.
