### PR TITLE
Adding mapEdges and mapTriplets by Partition

### DIFF
--- a/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartition.scala
@@ -57,6 +57,25 @@ class EdgePartition[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) 
   }
 
   /**
+   * Construct a new edge partition by using the edge attributes
+   * contained in the iterator.
+   *
+   * @note The input iterator should return edge attributes in the
+   * order of the edges returned by `EdgePartition.iterator` and
+   * should return attributes equal to the number of edges.
+   *
+   * @param f a function from an edge to a new attribute
+   * @tparam ED2 the type of the new attribute
+   * @return a new edge partition with the result of the function `f`
+   *         applied to each edge
+   */
+  def map[ED2: ClassManifest](iter: Iterator[ED2]): EdgePartition[ED2] = {
+    val newData = iter.toArray
+    assert(newData.size == data.size)
+    new EdgePartition(srcIds, dstIds, newData, index)
+  }
+
+  /**
    * Apply the function f to all edges in this partition.
    *
    * @param f an external state mutating user defined function.

--- a/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartition.scala
+++ b/graph/src/main/scala/org/apache/spark/graph/impl/EdgePartition.scala
@@ -70,8 +70,13 @@ class EdgePartition[@specialized(Char, Int, Boolean, Byte, Long, Float, Double) 
    *         applied to each edge
    */
   def map[ED2: ClassManifest](iter: Iterator[ED2]): EdgePartition[ED2] = {
-    val newData = iter.toArray
-    assert(newData.size == data.size)
+    val newData = new Array[ED2](data.size)
+    var i = 0
+    while (iter.hasNext) {
+      newData(i) = iter.next()
+      i += 1
+    }
+    assert(newData.size == i)
     new EdgePartition(srcIds, dstIds, newData, index)
   }
 


### PR DESCRIPTION
These functions were added to support random number generation while transforming edge attributes in a deterministic fashion.  

To support these changes consistently, I pass the partition Id along with the EdgePartition in EdgeRDD operations.
